### PR TITLE
Incorporate corporate structure data

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -75,7 +75,7 @@ domains/companies/
   hooks/       domain-specific hooks
   stores/      Zustand stores
   types.ts     domain types
-  mock-detail.ts / other domain-owned data helpers
+  mock-sections.ts / other domain-owned data helpers
 ```
 
 - A domain may import: `components/`, top-level `blocks/`, `lib/`, `types/`,
@@ -256,8 +256,14 @@ manually (Base UI forwards refs internally).
 Quick spot-checks that the codebase still matches this doc:
 
 ```bash
-# No cross-domain imports
-grep -rn "@/domains/" web/src/domains
+# No cross-domain imports. A domain referencing its OWN path alias is fine, so
+# each domain is checked against everything except itself — a bare
+# `grep -rn "@/domains/" web/src/domains` reports every intra-domain import as a
+# false positive.
+for d in web/src/domains/*/; do
+  n=$(basename "$d")
+  grep -rn "@/domains/" "$d" | grep -v "@/domains/$n/"
+done
 
 # No default exports outside app/
 grep -rn "export default" web/src/{components,blocks,domains,views,layouts,hooks,lib,types}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,6 +50,7 @@ jobs:
         working-directory: project/jobs
         env:
           COMPANY_INFO_FILE_PATH: ${{ github.workspace }}/project/${{ vars.INPUT_DATA_DIR }}/${{ vars.COMPANY_INFO_FILE_PATH }}
+          CORPORATE_STRUCTURE_FILE_PATH: ${{ github.workspace }}/project/${{ vars.INPUT_DATA_DIR }}/${{ vars.CORPORATE_STRUCTURE_FILE_PATH }}
           OUTPUT_FILE_PATH: ${{ github.workspace }}/project/${{ vars.OUTPUT_DATA_DIR }}/${{ vars.OUTPUT_FILE_NAME }}
 
       - name: Cache dataset

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,40 @@
 
 This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
 
+## Web app architecture — read before editing `web/`
+
+`web/src/` has codified architectural conventions in
+[.claude/ARCHITECTURE.md](.claude/ARCHITECTURE.md). **Read it before writing,
+moving, or adding any file under `web/src/`, and follow it.**
+
+Note the path: it lives in `.claude/`, not the repo root. Do not conclude the
+project has no conventions just because there is no top-level
+`ARCHITECTURE.md` — that mistake has already been made.
+
+The doc is normative, not descriptive. In its own words: *"When a rule and the
+code disagree, the rule is the target — bring the code back rather than the
+doc."* So a violation you find in existing code is a bug to be fixed or filed,
+not a precedent to copy.
+
+Read it in full before adding a folder, a hook, or your first component. The
+rules that break most often all follow from imports flowing strictly downward:
+
+- A file in `components/` must not import from another file in `components/`.
+- A file in `blocks/` must not import from another file in `blocks/`.
+- A file in `domains/a/` must not import from `domains/b/`.
+
+When two peers need the same logic, it moves **down** a layer (`lib/`, `hooks/`,
+`types/`) — never sideways. A hook or helper starts inside its domain and is
+promoted to top level only once a caller from another layer actually exists.
+
+Also load-bearing, and easy to violate without noticing: every class string goes
+through `cn()`, colors come from semantic tokens rather than hex, exports are
+named (no `export default` outside the files Next requires), and the site is
+fully static — there is no server runtime and no request-time fetching.
+
+The doc's **Verification** section has grep commands that confirm the codebase
+still complies. Run them after any structural change.
+
 ## Quick Reference
 
 ```bash

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -210,6 +210,19 @@ would disagree only for a 10-K filed late for a period older than an on-time
 earlier filing; no CIK in the dataset does that. Blank `report_date` (seven
 20FR12B rows) loses to any real date and otherwise falls through to accession.
 
+**`asOf` is the filing date, and `report_date` is deliberately not surfaced.** A
+subsidiary list describes the registrant as of its fiscal period end, so
+`report_date` has a claim to being the truer as-of. Filing date wins anyway: it
+is the date a reader verifies against EDGAR, and it is what the tree's subtitle
+range and the same-day tie-break already sort on. Surfacing both was considered
+and dropped as a field the UI would have to explain twice.
+
+That makes the *wording* load-bearing. The gap between the two dates runs 34 to
+238 days, median 58, and 113 of the 134 companies with a tree report a fiscal
+year different from the year they filed in — FY2016 structures under a 2017
+date. So every rendered date says "filed on", never a bare date that a reader
+could take for a period end. See `SourceCitation`'s `detail` prop.
+
 **No recency filter is applied to `filing_date`.** The tech spec says "filings
 from the past 2 years", which would currently yield *zero* companies — every
 matched company's most recent filing is 2016–2018, because the dataset is a

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -74,7 +74,9 @@ a 1:1 grain.
 | `Company` field | Source column |
 | --- | --- |
 | `permId` | `permid_id` |
-| `cik` | `identifier` where `identifier_type == "cik"` |
+| `cik` | the primary of `registrants`, via `select_primary_cik` |
+| `registrants[].cik` | every `identifier` where `identifier_type == "cik"` |
+| `registrants[].registrantName` | `entity_name`, from that CIK's most recent row |
 | `lei` | `lei` |
 | `name` | `investor_name` |
 | `foundedOn` | `founded_date` |
@@ -90,7 +92,14 @@ a 1:1 grain.
 | `sources[].url` | `permid_url` |
 | `sources[].lastAccessed` | `last_processed` |
 
-Unused columns: `entity_name`, `input_source`, `identifier_type` and
+`input_source` and `last_processed` together partition a PermID's rows into
+snapshots. Company-level scalars come from the most recent one rather than from
+whichever row parquet happened to put first; `registrants` unions across all of
+them, because recency decides field *values*, not which registrants exist. Rows
+of a single snapshot disagreeing on a scalar raises a WARNING — they were all
+built from one upstream record, so they should agree.
+
+Unused columns: `identifier_type` and
 `standard_identifier` (routing only), `registered_address`, `fax_number`,
 `phone_number`, `activity_status`, `ric`, and the three `*_comment` fields
 (taxonomy descriptions, not company facts).
@@ -139,10 +148,19 @@ normalizes to `None` for `exchangeMic` while `exchangeCode` still carries the
 value, so those companies are not silently delisted. Coverage: 163 rows have a
 MIC, 179 have a code, and the code set is a superset of the MIC set.
 
-**`cik` is null unless unambiguous.** The data spec calls for Primary CIK
-selection logic but does not define it. Guessing a tie-break would attach the
-wrong filings to a company, so a PermID with several CIKs gets `null` and a log
-line.
+**`cik` is the primary registrant, and every CIK is kept.** A PermID may cover
+several SEC registrants — holdco/opco pairs, REIT/operating-partnership pairs,
+utility groups. All of them land in `registrants`; `cik` mirrors the one marked
+`isPrimary` and is null only when the company has no CIK at all. An earlier
+version nulled `cik` whenever a PermID carried more than one, which also cost
+those companies their corporate tree.
+
+Primary selection is a **stub** in `select_primary_cik`: lowest CIK, which is
+deterministic and demonstrably wrong for some groups — it picks Entergy Arkansas
+over Entergy Corp, and NSTAR Electric over Eversource Energy. The docstring
+carries the evidence and the intended replacement. It matters only for joining
+per-CIK datasets and for choosing one extraction per accession; it does not
+decide displayed identity.
 
 **HQ country is positional parsing of free text.** The country is the last line
 of `hq_address`. All 219 rows currently end in a country, but nothing guarantees
@@ -193,12 +211,71 @@ it was the *only* row, so it correctly ends up with no disclosed structure.
 
 **`location` is a jurisdiction, not a country, and is not normalized.** 317
 distinct values mixing US states and countries, with `Delaware`, `DE`, and
-`DELAWARE` all present, and 493 blanks. Blank becomes `None`. Do not "clean" this
-into a country field; the value is what the filing says.
+`DELAWARE` all present, and 493 blanks — both figures over the 8,807 rows that
+actually render, not the whole file. Dataset-wide it is 3,205 distinct values
+and 32,076 blanks. Blank becomes `None`. Do not "clean" this into a country
+field; the value is what the filing says.
 
 **`last_processed` is compact basic ISO** (`20260801T033040`), unlike the
 `YYYY-MM-DD` used elsewhere in the spec. Parsed defensively because the upstream
 format is unsettled.
+
+## The per-CIK join contract
+
+Corporate structure is the first per-CIK dataset to land. Shareholders and
+commercial debt are both coming, and both join the same way. The rule is written
+down once here so those two processors do not each invent their own.
+
+**1. Join on every registrant, not on `Company.cik`.** The join key is all of
+`Company.registrants[].cik`. `cik` is a display convenience naming the primary;
+using it as the join key silently drops every filing made by a company's other
+registrants.
+
+**2. One extraction per `accession_number`.** Co-registrants on a combined
+filing are each attributed the same document, so a union across CIKs multiplies
+rows — AEP's six CIKs carry the same 22 names, for 132 rows describing 22
+subsidiaries. Keep exactly one CIK's rows per accession: the primary's if it is
+among them, else the lowest.
+
+Take one *whole* copy rather than merging. The extractions are not identical —
+on 68 of the 203 shared accessions the processor reports different row counts
+per CIK, and Brixmor reads 619 rows under one CIK and 633 under the other from
+one `exhibit_url`. These are LLM parses of a single document with no basis for
+ranking them, and merging produces a list neither parse returned (634, in
+Brixmor's case).
+
+**3. Stamp `disclosedByCik` on every row.** A company renders one flat list, so
+without it the rows lose track of which registrant disclosed them.
+
+**4. Cite the disclosing registrant's document, not the primary's.** Each row's
+`sources` points at the exhibit it actually came from.
+
+**Not in the contract: deduping by entity name across documents.** Two
+registrants who file separately both contribute in full, so a subsidiary named
+in both appears twice. This is deferred rather than decided, because both
+obvious keys are wrong in opposite directions. Measured over the rows that
+render today:
+
+| Key | Failure |
+| --- | --- |
+| case-folded `name` | over-merges the **214** duplicate-name groups carrying two genuinely different non-blank jurisdictions |
+| `(name, jurisdiction)` | under-merges the **252** groups where one row has a jurisdiction and the other is blank, splitting one subsidiary in two |
+
+Blanks are common enough to matter — 493 of the 8,807 rendered rows, 32,076 of
+445,818 file-wide — so any rule keying on the pair has to say what a blank
+means. Folding a blank into a filled row of the same name avoids both failures
+on this data and is the current front-runner, but it is not a decision.
+
+Two caveats for whoever takes it: those counts are measured *within* one
+accession, because that is where duplicate names are observable today, while the
+deferred case is *across* accessions where two independent parses also disagree
+on spelling and punctuation — a strict key will under-merge more than these
+numbers suggest. And extraction noise is already in the counts: both Brixmor
+parses carry a literal `Legal Entity Name` row, the exhibit's table header read
+as a subsidiary.
+
+`attach_relationships` logs the duplicate-name count surviving across accessions
+on every run, so the evidence accumulates without anyone re-deriving it.
 
 ## Scope
 

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -2,30 +2,34 @@
 
 Build-time data pipeline for the static web application.
 
-`build_dataset.py` reads the company info processor's output and writes JSON
-records matching the serialized `Company` type in
+`build_dataset.py` reads the company info and corporate structure processors'
+outputs and writes JSON records matching the serialized `Company` type in
 [`web/src/types/domain.ts`](../web/src/types/domain.ts). That TypeScript type is
 the contract; if you change the shape here, change it there in the same commit.
 
 ## Running it
 
 ```bash
-COMPANY_INFO_FILE_PATH=../data/input/latest_company_info.parquet OUTPUT_FILE_PATH=../data/output/companies.json uv run python build_dataset.py
+COMPANY_INFO_FILE_PATH=../data/input/latest_company_info.parquet \
+CORPORATE_STRUCTURE_FILE_PATH=../data/input/latest_corporate_structure.parquet \
+OUTPUT_FILE_PATH=../data/output/companies.json \
+uv run python build_dataset.py
 ```
 
 | Variable | Meaning |
 | --- | --- |
 | `COMPANY_INFO_FILE_PATH` | `company-info/latest.parquet` from the processed layer |
+| `CORPORATE_STRUCTURE_FILE_PATH` | `corporate-structure/latest.parquet` from the processed layer |
 | `OUTPUT_FILE_PATH` | Where to write the JSON the web build consumes |
 
-In CI both are set by [`deploy.yaml`](../.github/workflows/deploy.yaml), which
+In CI all three are set by [`deploy.yaml`](../.github/workflows/deploy.yaml), which
 first syncs the processed layer out of S3. The web build then reads the output
 via `INPUT_DATA_FILE_PATH`.
 
 `data/` is gitignored, so the parquet and the JSON are local artifacts — not
 fixtures committed to the repo.
 
-## Input
+## Input 1 — company info
 
 `s3://{bucket}/database/company-info/latest.parquet`, produced by the IDI
 company info processor from the LSEG PermID Entity Match and PermID Info APIs.
@@ -61,6 +65,37 @@ Unused columns: `entity_name`, `input_source`, `identifier_type` and
 `standard_identifier` (routing only), `registered_address`, `fax_number`,
 `phone_number`, `activity_status`, `ric`, and the three `*_comment` fields
 (taxonomy descriptions, not company facts).
+
+## Input 2 — corporate structure
+
+`s3://{bucket}/database/corporate-structure/latest.parquet`, produced by the IDI
+corporate structure processor from Exhibit 21 of 10-K filings and Exhibit 8 of
+20-F filings. One row per disclosed subsidiary per filing, and a full historical
+record — most registrants appear with more than one filing date.
+
+Populates `Company.currentCorporateRelationships`:
+
+| `CurrentCorporateRelationship` field | Source column |
+| --- | --- |
+| `child.name` | `name` |
+| `childJurisdiction` | `location` |
+| `asOf` | `filing_date` |
+| `sources[].name` | derived from `form_type` + `exhibit_type` |
+| `sources[].url` | `exhibit_url` |
+| `sources[].lastAccessed` | `date_added`, date component |
+| (join key) | `parent_cik` |
+| (tie-break only) | `accession_number` |
+
+`parent` comes from the `Company` record, not from the dataset's `parent_name`.
+`child.permId` is always `None`: Exhibit 21 gives a name and a jurisdiction,
+never an identifier.
+
+Unused columns: `parent_name` (except to detect self-listing),
+`parent_state_of_incorporation`, the seven `parent_business_*` address fields,
+`parent_tickers`, `parent_exchanges`, and `source_quote`. Several of these would
+fill gaps in company-info's coverage, but company-info stays the single source
+for company identity — reconciling two sources for the same fact is its own
+problem, not something to do implicitly here.
 
 ## Decisions worth knowing before you change this
 
@@ -100,14 +135,50 @@ live on the `current*` fields instead. Do not populate a `historic*` array by
 inventing a `from` date; that was how the previous mock pipeline worked and it
 produced 1970-01-01 everywhere.
 
+**`parent_cik` is unpadded; company-info's CIK is zero-padded to 10.** This is
+the one thing here you cannot infer from reading the code, and getting it wrong
+does not raise: the naive join matches *zero* rows and every company page renders
+an empty Corporate Tree, which looks exactly like "the processor has no data
+yet". Both sides are normalized through `normalize_cik` before joining, and an
+empty join fails the build rather than shipping 219 blank sections.
+
+**Only the most recent filing per company contributes subsidiaries.** 111 of the
+133 matched companies have more than one filing date. Merging rows across filings
+would describe a structure no single document supports. Ties on filing date break
+on the highest `accession_number` so runs are reproducible.
+
+**No recency filter is applied to `filing_date`.** The tech spec says "filings
+from the past 2 years", which would currently yield *zero* companies — every
+matched company's most recent filing is 2016–2018, because the dataset is a
+partial backfill. The UI shows the filing date instead, so a 2017 list is never
+presented as current.
+
+**`exhibit_type` is not filtered.** It takes two values and both are subsidiary
+lists: `21` is the 10-K's Exhibit 21, `8` is the 20-F's Exhibit 8.1. Filtering to
+`21` would silently drop every foreign private issuer. No 20-F filer is in the
+current 219-company universe, so that path is correct but unexercised.
+
+**A registrant listing itself is dropped.** Six rows do this. That is the tree's
+root, not one of its own subsidiaries — and for one company (SpendSmart Networks)
+it was the *only* row, so it correctly ends up with no disclosed structure.
+
+**`location` is a jurisdiction, not a country, and is not normalized.** 317
+distinct values mixing US states and countries, with `Delaware`, `DE`, and
+`DELAWARE` all present, and 493 blanks. Blank becomes `None`. Do not "clean" this
+into a country field; the value is what the filing says.
+
 **`last_processed` is compact basic ISO** (`20260801T033040`), unlike the
 `YYYY-MM-DD` used elsewhere in the spec. Parsed defensively because the upstream
 format is unsettled.
 
 ## Scope
 
-The parquet currently covers only companies reached via the commercial debt
-tracker — 219 PermIDs. Shareholder Tracker and Corporate Structure inputs are
-not yet included, so the company universe grows as those processors land. No
-filtering is applied here, including on `activity_status`: inactive companies
-still get records.
+The company universe is set by company-info, which currently covers only
+companies reached via the commercial debt tracker — 219 PermIDs. It grows as the
+Shareholder Tracker lands. No filtering is applied here, including on
+`activity_status`: inactive companies still get records.
+
+Corporate structure covers 4,652 registrants, but only those that are also in the
+company universe get a tree: **133 of 219** companies, carrying 8,807
+subsidiaries between them. The other 86 render an empty state. That ratio
+improves from both directions as the two processors fill in.

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -29,6 +29,35 @@ via `INPUT_DATA_FILE_PATH`.
 `data/` is gitignored, so the parquet and the JSON are local artifacts — not
 fixtures committed to the repo.
 
+## Fixtures
+
+```bash
+uv run python -m fixtures            # every case
+uv run python -m fixtures multi_cik  # cases whose name contains "multi_cik"
+```
+
+Exits non-zero if any case fails. There is no test framework in this repo, and
+[`fixtures/`](fixtures/) is not one — it is a runner over synthetic inputs,
+built because some `build_dataset` behavior **cannot be exercised against
+production data at all**. No PermID currently carries more than one CIK, so
+every multi-CIK path is covered by these cases or by nothing.
+
+A case declares only the columns it cares about and inherits the rest from
+`DEFAULT_COMPANY_ROW` / `DEFAULT_STRUCTURE_ROW`, so adding one is a few lines in
+[`fixtures/cases.py`](fixtures/cases.py) and never touches the harness. An
+override naming a column the real schema lacks raises rather than being
+ignored — otherwise a typo'd column silently disables the assertion it was
+written to drive.
+
+Cases run the pipeline end to end through `build_dataset.main`, writing real
+parquet to a temp dir, because the failures worth catching are in how the stages
+compose. `run_build` returns the emitted records plus the captured log, so a
+case can assert on a WARNING as easily as on a field.
+
+These live under `jobs/` rather than `data/fixtures/` for the reason stated
+above: `data/` is gitignored, and a fixture that is not committed is not
+coverage.
+
 ## Input 1 — company info
 
 `s3://{bucket}/database/company-info/latest.parquet`, produced by the IDI

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -122,7 +122,7 @@ Populates `Company.currentCorporateRelationships`:
 | `sources[].url` | `exhibit_url` |
 | `sources[].lastAccessed` | `date_added`, date component |
 | (join key) | `parent_cik` |
-| (tie-break only) | `accession_number` |
+| (tie-break only) | `report_date`, then `accession_number` |
 
 `parent` comes from the `Company` record, not from the dataset's `parent_name`.
 `child.permId` is always `None`: Exhibit 21 gives a name and a jurisdiction,
@@ -191,8 +191,24 @@ empty join fails the build rather than shipping 219 blank sections.
 
 **Only the most recent filing per company contributes subsidiaries.** 111 of the
 133 matched companies have more than one filing date. Merging rows across filings
-would describe a structure no single document supports. Ties on filing date break
-on the highest `accession_number` so runs are reproducible.
+would describe a structure no single document supports. Filings are ordered by
+`filing_date`, then `report_date`, then `accession_number`.
+
+**Same-day ties are catch-up filings, not amendments, so `report_date` breaks
+them.** All three CIKs carrying more than one accession on their latest
+`filing_date` are delinquent registrants that filed several years of 10-Ks at
+once. Accession number cannot order those: it follows the filer agent and
+submission sequence, not the fiscal period. DOC DR, LLC (CIK 1583994) filed its
+FY2014 and FY2016 10-Ks on 2017-02-24 through different agents, and the higher
+accession is FY2014 — 94 subsidiaries where FY2016 discloses 261. Accession
+number stays as the last tie-break, for reproducibility when two filings share
+both dates.
+
+`filing_date` stays the primary sort rather than `report_date`, so "most recent
+filing" keeps meaning what it says and matches the date shown to users. The two
+would disagree only for a 10-K filed late for a period older than an on-time
+earlier filing; no CIK in the dataset does that. Blank `report_date` (seven
+20FR12B rows) loses to any real date and otherwise falls through to accession.
 
 **No recency filter is applied to `filing_date`.** The tech spec says "filings
 from the past 2 years", which would currently yield *zero* companies — every

--- a/jobs/build_dataset.py
+++ b/jobs/build_dataset.py
@@ -61,6 +61,30 @@ US_STATES: frozenset[str] = frozenset(
 # fall through to that rather than being treated as missing.
 UNKNOWN_MIC = "XXXX"
 
+# Company-level columns, all read off one winning row. Rows sharing an
+# (input_source, last_processed) partition were built from a single
+# `permid_data.json`, so these must agree inside a partition -- see
+# `warn_on_snapshot_divergence`.
+#
+# Deliberately excluded: `identifier`, `entity_name` and `standard_identifier`
+# are per-CIK and are *supposed* to differ; `ticker` is excluded because one
+# snapshot can legitimately report several for a genuinely multi-ticker company.
+SCALAR_COMPANY_FIELDS: tuple[str, ...] = (
+    "permid_url",
+    "investor_name",
+    "lei",
+    "founded_date",
+    "hq_address",
+    "incorporated_in",
+    "domiciled_in",
+    "url",
+    "exchange",
+    "exchange_code",
+    "primary_industry_group_label",
+    "primary_economic_sector_label",
+    "primary_business_sector_label",
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -82,6 +106,29 @@ def _clean(value: object) -> str | None:
     return text or None
 
 
+def parse_last_processed_timestamp(value: object) -> pd.Timestamp:
+    """Parses LSEG's `last_processed` stamp to a comparable timestamp.
+
+    Used for ordering snapshots, which needs the time component that
+    `parse_last_processed` drops. The compact basic ISO form
+    ("20260801T033040") happens to string-sort correctly, but the upstream
+    format is unsettled, so it is parsed rather than compared as text.
+
+    Args:
+        value: A raw `last_processed` cell.
+
+    Returns:
+        A `pd.Timestamp`, or `pd.NaT` if it could not be parsed.
+    """
+    text = _clean(value)
+    if not text:
+        return pd.NaT
+    parsed = pd.to_datetime(text, format="%Y%m%dT%H%M%S", errors="coerce")
+    if pd.isna(parsed):
+        parsed = pd.to_datetime(text, errors="coerce")
+    return parsed
+
+
 def parse_last_processed(value: object) -> str | None:
     """Converts LSEG's `last_processed` stamp to an ISO-8601 date.
 
@@ -95,12 +142,7 @@ def parse_last_processed(value: object) -> str | None:
     Returns:
         An ISO-8601 date string, or `None` if it could not be parsed.
     """
-    text = _clean(value)
-    if not text:
-        return None
-    parsed = pd.to_datetime(text, format="%Y%m%dT%H%M%S", errors="coerce")
-    if pd.isna(parsed):
-        parsed = pd.to_datetime(text, errors="coerce")
+    parsed = parse_last_processed_timestamp(value)
     if pd.isna(parsed):
         return None
     return parsed.strftime("%Y-%m-%d")
@@ -343,13 +385,99 @@ def normalize_cik(values: pd.Series) -> pd.Series:
 # ---------------------------------------------------------------------------
 
 
+def select_latest_snapshot(group: pd.DataFrame) -> pd.DataFrame:
+    """Reduces a PermID's rows to those of its most recent snapshot.
+
+    A PermID gets one row per (source, entity, identifier) link, and rows
+    multiply two ways. Several CIKs under one source all read the same
+    `permid_data.json`, so every company field including `last_processed` is
+    identical. One CIK under several sources was fetched once per source --
+    caches are per-source -- so `last_processed` differs and the company fields
+    can differ with it, if LSEG changed between runs.
+
+    That second case is what makes `group.iloc[0]` wrong: it picks a snapshot by
+    row order. Recency is the discriminator, tie-broken on `input_source` so the
+    choice is stable across runs rather than dependent on parquet row order.
+
+    Rows whose `last_processed` cannot be parsed sort as oldest, so any row with
+    a real stamp beats them.
+
+    Args:
+        group: All source rows for a single PermID.
+
+    Returns:
+        The subset of `group` sharing the winning
+        `(last_processed, input_source)` partition. Never empty.
+    """
+    order = pd.DataFrame(
+        {
+            "ts": group["last_processed"].map(parse_last_processed_timestamp),
+            "src": group["input_source"].map(lambda v: _clean(v) or ""),
+        },
+        index=group.index,
+    )
+    ranked = order.sort_values(
+        ["ts", "src"], ascending=[False, True], na_position="last"
+    )
+    win_ts = ranked["ts"].iloc[0]
+    win_src = ranked["src"].iloc[0]
+
+    if pd.isna(win_ts):
+        matches = order["ts"].isna()
+    else:
+        matches = order["ts"] == win_ts
+    return group[matches & (order["src"] == win_src)]
+
+
+def warn_on_snapshot_divergence(
+    group: pd.DataFrame, perm_id: str | None, logger: logging.Logger
+) -> None:
+    """Warns when rows of a single snapshot disagree on a company-level field.
+
+    Rows sharing an `(input_source, last_processed)` partition were all built
+    from one `permid_data.json`, so a disagreement between them should be
+    impossible and means something upstream is wrong.
+
+    Divergence *across* snapshots is expected -- that is exactly what
+    `select_latest_snapshot` resolves -- and is deliberately not reported here.
+    Warning on it would fire for every company reached by more than one source,
+    which is noise rather than signal.
+
+    Args:
+        group: All source rows for a single PermID.
+        perm_id: The PermID, named in the warning.
+        logger: A standard logger instance.
+    """
+    for (source, stamp), partition in group.groupby(
+        ["input_source", "last_processed"], dropna=False, sort=False
+    ):
+        if len(partition) < 2:
+            continue
+        for column in SCALAR_COMPANY_FIELDS:
+            if column not in partition.columns:
+                continue
+            values = {_clean(value) for value in partition[column]}
+            if len(values) > 1:
+                logger.warning(
+                    'PermID %s: field "%s" holds %d distinct values within one '
+                    "snapshot (input_source=%s, last_processed=%s): %s. Rows of "
+                    "one snapshot come from a single upstream record, so they "
+                    "should agree; the most recent row still wins.",
+                    perm_id,
+                    column,
+                    len(values),
+                    source,
+                    stamp,
+                    ", ".join(repr(v) for v in sorted(values, key=str)),
+                )
+
+
 def transform_company(group: pd.DataFrame, logger: logging.Logger) -> dict:
     """Builds one Company record from all rows sharing a PermID.
 
     The grain of the source is one row per (identifier_type, identifier), so a
-    PermID may eventually carry several CIKs — the Shareholder Tracker will
-    introduce these. Scalar fields take the first value; identifiers are
-    collected into lists.
+    PermID may carry several CIKs. Company-level fields are read off the most
+    recent snapshot; identifiers are collected across every row.
 
     Args:
         group: All source rows for a single PermID.
@@ -359,13 +487,25 @@ def transform_company(group: pd.DataFrame, logger: logging.Logger) -> dict:
         A dict matching the serialized `Company` type in
         `web/src/types/domain.ts`.
     """
-    first = group.iloc[0]
+    perm_id = _clean(group.iloc[0]["permid_id"])
+    warn_on_snapshot_divergence(group, perm_id, logger)
 
-    perm_id = _clean(first["permid_id"])
+    latest = select_latest_snapshot(group)
+    first = latest.iloc[0]
+
     as_of = parse_last_processed(first["last_processed"])
     sources = build_sources(_clean(first["permid_url"]), as_of)
 
-    tickers = _collect(group["ticker"])
+    # Tickers come from the winning snapshot only. Collecting across the whole
+    # group would surface both sides of a ticker change between runs, producing
+    # a listing no single fetch ever reported. Within one snapshot `_collect`
+    # still handles a genuinely multi-ticker company.
+    tickers = _collect(latest["ticker"])
+
+    # CIKs are the one field collected across ALL rows regardless of recency.
+    # company-info is the record of every CIK that rolls up to a PermID, and
+    # recency decides field *values*, not which registrants exist -- filtering
+    # here would drop a CIK that arrived from a different source.
     ciks = _collect(group.loc[group["identifier_type"] == "cik", "identifier"])
 
     # Only claim a CIK when it is unambiguous. The data spec calls for Primary

--- a/jobs/build_dataset.py
+++ b/jobs/build_dataset.py
@@ -13,6 +13,18 @@ import pandas as pd
 
 SOURCE_NAME = "LSEG PermID"
 
+# SEC CIKs are canonically zero-padded to 10 digits, which is how company-info
+# reports them. The corporate-structure dataset reports them unpadded, so both
+# sides are normalized to this width before joining. Skipping this matches zero
+# rows -- see `attach_relationships`.
+CIK_WIDTH = 10
+
+# Exhibit 21 lists "Subsidiaries of the Registrant"; the 20-F equivalent is
+# "List of Subsidiaries". Neither reports an ownership percentage or a
+# relationship start date, so every emitted relationship is a plain subsidiary
+# with a null percent.
+RELATIONSHIP_TYPE = "Subsidiary"
+
 # LSEG's TRBC taxonomy is label-first and supplies no numeric code, unlike SIC
 # and NAICS. The `Sector.code` field is deliberately empty for these.
 SECTOR_SYSTEM = "TRBC"
@@ -273,11 +285,12 @@ def _collect(series: pd.Series) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def load_company_info(company_info_fpath: Path) -> pd.DataFrame:
-    """Loads the company info dataset produced by the IDI company processor.
+def load_parquet(fpath: str | Path, label: str) -> pd.DataFrame:
+    """Loads one processor's `latest.parquet` into a DataFrame.
 
     Args:
-        company_info_fpath: Path to `company-info/latest.parquet`.
+        fpath: Path to the parquet file.
+        label: Human-readable dataset name, used in error messages.
 
     Returns:
         The dataset as a Pandas DataFrame.
@@ -286,33 +299,43 @@ def load_company_info(company_info_fpath: Path) -> pd.DataFrame:
         `RuntimeError` if the path is not a single parquet file, or cannot be
             read as one.
     """
-    path = Path(company_info_fpath)
+    path = Path(fpath)
     # Insist on a file. Pointed at a directory, pyarrow reads it as a dataset
     # and schema-unions everything underneath — so a misconfigured path silently
-    # merges unrelated processors' outputs into the company list instead of
-    # failing. That is a data-integrity bug, not a config error, and it is
-    # invisible in the logs.
+    # merges unrelated processors' outputs into one table instead of failing.
+    # That is a data-integrity bug, not a config error, and it is invisible in
+    # the logs.
     if path.is_dir():
         raise RuntimeError(
-            f"Expected a parquet file but got a directory: {path}. "
+            f"Expected a parquet file for {label} but got a directory: {path}. "
             "Check that the input path includes the file name — reading a "
             "directory would merge every dataset beneath it."
         )
     if not path.exists():
-        raise RuntimeError(
-            f"The company info parquet file was not found at: {path}"
-        )
+        raise RuntimeError(f"The {label} parquet file was not found at: {path}")
 
     try:
         return pd.read_parquet(path)
     except FileNotFoundError as e:
         raise RuntimeError(
-            "The company info parquet file was not found at the given path."
+            f"The {label} parquet file was not found at the given path."
         ) from e
     except (OSError, ValueError) as e:
         raise RuntimeError(
-            "The company info file could not be read as a parquet dataset."
+            f"The {label} file could not be read as a parquet dataset."
         ) from e
+
+
+def normalize_cik(values: pd.Series) -> pd.Series:
+    """Normalizes a CIK column to the canonical zero-padded 10-digit form.
+
+    Args:
+        values: A column of CIKs, padded or not.
+
+    Returns:
+        The column as zero-padded strings.
+    """
+    return values.astype(str).str.strip().str.zfill(CIK_WIDTH)
 
 
 # ---------------------------------------------------------------------------
@@ -403,6 +426,9 @@ def transform_company(group: pd.DataFrame, logger: logging.Logger) -> dict:
             sources,
             as_of,
         ),
+        # Filled by `attach_relationships` once the corporate-structure dataset
+        # is joined; stays empty for companies with no disclosed subsidiaries.
+        "currentCorporateRelationships": [],
         # History — empty until a source supplies real date ranges. Do not
         # populate these by inventing a `from` date.
         "historicNames": [],
@@ -415,6 +441,168 @@ def transform_company(group: pd.DataFrame, logger: logging.Logger) -> dict:
         "historicSecurities": [],
         "historicProjectAffiliations": [],
     }
+
+
+def select_latest_filings(structure_df: pd.DataFrame) -> pd.DataFrame:
+    """Reduces the corporate-structure dataset to one filing per company.
+
+    `latest.parquet` is a full historical record, and most registrants appear
+    with more than one filing date. Rows from two filings merged together would
+    describe a corporate structure that no single document supports, so only the
+    most recent filing per CIK survives. Ties on filing date — a handful of
+    registrants amended on the same day — break on the highest accession
+    number, so the output is stable across runs.
+
+    Rows where the registrant lists itself are dropped: that is the tree's root,
+    not one of its own subsidiaries.
+
+    Args:
+        structure_df: The corporate-structure dataset, with a normalized `cik`.
+
+    Returns:
+        The subset of rows belonging to each company's most recent filing.
+    """
+    latest_date = structure_df.groupby("cik")["filing_date"].transform("max")
+    latest = structure_df[structure_df["filing_date"] == latest_date]
+
+    latest_accession = latest.groupby("cik")["accession_number"].transform("max")
+    latest = latest[latest["accession_number"] == latest_accession]
+
+    self_listed = (
+        latest["name"].str.strip().str.casefold()
+        == latest["parent_name"].str.strip().str.casefold()
+    )
+    return latest[~self_listed]
+
+
+def build_source_name(form_type: str | None, exhibit_type: str | None) -> str:
+    """Names the citation after the filing it came from.
+
+    Exhibit 21 is the 10-K's subsidiary list; the 20-F carries the same
+    disclosure as Exhibit 8. Reading both off the row keeps a 20-F from being
+    miscited as a 10-K.
+
+    Args:
+        form_type: The SEC form type, e.g. `"10-K"`.
+        exhibit_type: The exhibit number, e.g. `"21"`.
+
+    Returns:
+        A source name such as `"SEC 10-K Exhibit 21"`.
+    """
+    form = form_type or "filing"
+    if not exhibit_type:
+        return f"SEC {form}"
+    return f"SEC {form} Exhibit {exhibit_type}"
+
+
+def build_relationship(row: pd.Series, company: dict) -> dict:
+    """Builds one CurrentCorporateRelationship from a disclosed subsidiary.
+
+    The parent's name comes from the `Company` record rather than the dataset's
+    own `parent_name` column: company-info is the source for company identity,
+    and taking the name from two places invites them to disagree.
+
+    The child carries no `permId`. Exhibit 21 gives a name and a jurisdiction,
+    never an identifier, and resolving names to PermIDs is a fuzzy-matching
+    problem that belongs upstream rather than in a display join.
+
+    Args:
+        row: One subsidiary row from the corporate-structure dataset.
+        company: The parent's `Company` record.
+
+    Returns:
+        A dict matching the serialized `CurrentCorporateRelationship` type in
+        `web/src/types/domain.ts`.
+    """
+    return {
+        # CitedEntity
+        "sources": [
+            {
+                "name": build_source_name(
+                    _clean(row["form_type"]), _clean(row["exhibit_type"])
+                ),
+                "url": _clean(row["exhibit_url"]),
+                "lastAccessed": parse_iso_date(row["date_added"]),
+            }
+        ],
+        # SnapshotEntity — the date the relationship was disclosed, which is not
+        # the date it began. Do not reuse this as a `from`.
+        "asOf": parse_iso_date(row["filing_date"]),
+        "parent": {"name": company["name"], "permId": company["permId"]},
+        "child": {"name": _clean(row["name"]), "permId": None},
+        "relationshipType": RELATIONSHIP_TYPE,
+        "ownershipPercent": None,
+        "childJurisdiction": _clean(row["location"]),
+    }
+
+
+def attach_relationships(
+    companies: list[dict],
+    structure_df: pd.DataFrame,
+    logger: logging.Logger,
+) -> None:
+    """Attaches disclosed subsidiaries to the companies they belong to.
+
+    Mutates `companies` in place, filling `currentCorporateRelationships`.
+
+    Args:
+        companies: `Company` records, each with a `cik` that may be `None`.
+        structure_df: The raw corporate-structure dataset.
+        logger: A standard logger instance.
+
+    Raises:
+        `RuntimeError` if the CIK join matches no companies at all.
+    """
+    structure = structure_df.copy()
+    structure["cik"] = normalize_cik(structure["parent_cik"])
+    latest = select_latest_filings(structure)
+
+    by_cik = {cik: group for cik, group in latest.groupby("cik", sort=False)}
+
+    # A company with several CIKs carries none, pending the primary-CIK logic
+    # the data spec calls for but does not define. Those companies get no tree
+    # rather than a guessed one.
+    missing_cik = sum(1 for company in companies if not company["cik"])
+    if missing_cik:
+        logger.info(
+            "%d companies have no single CIK and cannot be joined to a "
+            "corporate structure.",
+            missing_cik,
+        )
+
+    matched = 0
+    for company in companies:
+        cik = company["cik"]
+        if not cik or cik not in by_cik:
+            continue
+        group = by_cik[cik]
+        company["currentCorporateRelationships"] = [
+            build_relationship(row, company)
+            for _, row in group.sort_values("name").iterrows()
+        ]
+        matched += 1
+
+    # Both sides must be zero-padded or the join silently matches nothing,
+    # leaving every company page with an empty Corporate Tree and no error. That
+    # is a data-integrity failure that looks exactly like "the processor has no
+    # data yet", so it fails the build instead.
+    if not matched:
+        raise RuntimeError(
+            "The corporate-structure CIK join matched no companies. Sample "
+            f"parent_cik: {structure['cik'].iloc[0] if len(structure) else 'n/a'}; "
+            f"sample company CIK: {companies[0]['cik'] if companies else 'n/a'}. "
+            f"Both must be zero-padded to {CIK_WIDTH} digits."
+        )
+
+    total = sum(len(c["currentCorporateRelationships"]) for c in companies)
+    logger.info(
+        "Attached %d subsidiaries to %d of %d companies; %d have no disclosed "
+        "corporate structure.",
+        total,
+        matched,
+        len(companies),
+        len(companies) - matched,
+    )
 
 
 def build_companies(companies_df: pd.DataFrame, logger: logging.Logger) -> list[dict]:
@@ -443,11 +631,14 @@ def build_companies(companies_df: pd.DataFrame, logger: logging.Logger) -> list[
 def main(logger: logging.Logger) -> None:
     """Builds the company dataset consumed by the static web application.
 
-    Reads `company-info/latest.parquet` and writes JSON records matching the
+    Reads `company-info/latest.parquet` and
+    `corporate-structure/latest.parquet` and writes JSON records matching the
     serialized `Company` type in `web/src/types/domain.ts`.
 
     Environment variables:
         COMPANY_INFO_FILE_PATH: Path to the company info parquet file.
+        CORPORATE_STRUCTURE_FILE_PATH: Path to the corporate structure parquet
+            file.
         OUTPUT_FILE_PATH: Path to write the output JSON file.
 
     Args:
@@ -463,20 +654,32 @@ def main(logger: logging.Logger) -> None:
     logger.info("Parsing environment variables.")
     try:
         company_info_fpath = os.environ["COMPANY_INFO_FILE_PATH"]
+        corporate_structure_fpath = os.environ["CORPORATE_STRUCTURE_FILE_PATH"]
         output_fpath = os.environ["OUTPUT_FILE_PATH"]
     except KeyError as e:
         raise RuntimeError(f'Missing required environment variable "{e}".') from e
 
     logger.info("Loading company info dataset.")
-    companies_df = load_company_info(company_info_fpath)
+    companies_df = load_parquet(company_info_fpath, "company info")
     logger.info(
         "Loaded %d rows covering %d PermIDs.",
         len(companies_df),
         companies_df["permid_id"].nunique(),
     )
 
+    logger.info("Loading corporate structure dataset.")
+    structure_df = load_parquet(corporate_structure_fpath, "corporate structure")
+    logger.info(
+        "Loaded %d rows covering %d registrants.",
+        len(structure_df),
+        structure_df["parent_cik"].nunique(),
+    )
+
     logger.info("Transforming to Company records.")
     companies = build_companies(companies_df, logger)
+
+    logger.info("Attaching disclosed corporate structures.")
+    attach_relationships(companies, structure_df, logger)
 
     with_ticker = sum(1 for c in companies if (c["currentListing"] or {}).get("ticker"))
     with_exchange = sum(

--- a/jobs/build_dataset.py
+++ b/jobs/build_dataset.py
@@ -662,9 +662,23 @@ def select_latest_filings(structure_df: pd.DataFrame) -> pd.DataFrame:
     `latest.parquet` is a full historical record, and most registrants appear
     with more than one filing date. Rows from two filings merged together would
     describe a corporate structure that no single document supports, so only the
-    most recent filing per CIK survives. Ties on filing date — a handful of
-    registrants amended on the same day — break on the highest accession
-    number, so the output is stable across runs.
+    most recent filing per CIK survives.
+
+    Same-day ties are not amendments. All three CIKs that carry more than one
+    accession on their latest `filing_date` are delinquent registrants that
+    caught up by filing several years of 10-Ks at once, so the tie is between
+    fiscal periods and `report_date` decides it. Accession number cannot: it
+    orders by filer agent and submission sequence, not by period. DOC DR, LLC
+    (CIK 1583994) filed its FY2014 and FY2016 10-Ks on 2017-02-24 through
+    different agents, and the higher accession is the FY2014 one — 94 disclosed
+    subsidiaries where FY2016 has 261. Accession number stays as the final
+    tie-break so the output is still stable across runs when two filings share
+    both dates.
+
+    `filing_date` remains the primary sort rather than `report_date`, so "most
+    recent filing" keeps meaning what it says and matches the date rendered to
+    users. That distinction only bites for a late-filed 10-K covering an older
+    period than an on-time earlier filing, which no CIK in the dataset does.
 
     Rows where the registrant lists itself are dropped: that is the tree's root,
     not one of its own subsidiaries.
@@ -675,11 +689,16 @@ def select_latest_filings(structure_df: pd.DataFrame) -> pd.DataFrame:
     Returns:
         The subset of rows belonging to each company's most recent filing.
     """
-    latest_date = structure_df.groupby("cik")["filing_date"].transform("max")
-    latest = structure_df[structure_df["filing_date"] == latest_date]
-
-    latest_accession = latest.groupby("cik")["accession_number"].transform("max")
-    latest = latest[latest["accession_number"] == latest_accession]
+    latest = structure_df
+    for column in ("filing_date", "report_date", "accession_number"):
+        # Blanks lose to any real value in the same group — seven 20FR12B rows
+        # carry an empty `report_date`. Nulls are filled first because NaN does
+        # not equal itself, so a group of all-null values would match no row and
+        # silently cost that CIK its whole tree instead of falling through to
+        # the next tie-break.
+        values = latest[column].fillna("")
+        winner = values.groupby(latest["cik"]).transform("max")
+        latest = latest[values == winner]
 
     self_listed = (
         latest["name"].str.strip().str.casefold()

--- a/jobs/build_dataset.py
+++ b/jobs/build_dataset.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+from collections import Counter
 from pathlib import Path
 
 # Third-party imports
@@ -745,6 +746,10 @@ def build_relationship(row: pd.Series, company: dict) -> dict:
         "relationshipType": RELATIONSHIP_TYPE,
         "ownershipPercent": None,
         "childJurisdiction": _clean(row["location"]),
+        # Which of the company's registrants disclosed this. A multi-registrant
+        # company renders one flat tree, so without this the rows lose track of
+        # who said what.
+        "disclosedByCik": _clean(row["cik"]),
     }
 
 
@@ -758,7 +763,7 @@ def attach_relationships(
     Mutates `companies` in place, filling `currentCorporateRelationships`.
 
     Args:
-        companies: `Company` records, each with a `cik` that may be `None`.
+        companies: `Company` records, each carrying a `registrants` list.
         structure_df: The raw corporate-structure dataset.
         logger: A standard logger instance.
 
@@ -771,26 +776,73 @@ def attach_relationships(
 
     by_cik = {cik: group for cik, group in latest.groupby("cik", sort=False)}
 
-    # A company with several CIKs carries none, pending the primary-CIK logic
-    # the data spec calls for but does not define. Those companies get no tree
-    # rather than a guessed one.
-    missing_cik = sum(1 for company in companies if not company["cik"])
-    if missing_cik:
+    no_registrants = sum(1 for company in companies if not company["registrants"])
+    if no_registrants:
         logger.info(
-            "%d companies have no single CIK and cannot be joined to a "
+            "%d companies have no CIK at all and cannot be joined to a "
             "corporate structure.",
-            missing_cik,
+            no_registrants,
         )
 
     matched = 0
+    multi_registrant = 0
+    dropped_to_accession_collapse = 0
+    duplicate_names_across_accessions = 0
+
     for company in companies:
-        cik = company["cik"]
-        if not cik or cik not in by_cik:
+        groups = [
+            by_cik[registrant["cik"]]
+            for registrant in company["registrants"]
+            if registrant["cik"] in by_cik
+        ]
+        if not groups:
             continue
-        group = by_cik[cik]
+        if len(groups) > 1:
+            multi_registrant += 1
+
+        rows = pd.concat(groups)
+        primary = company["cik"]
+
+        # Co-registrants on a combined filing are each attributed the same
+        # exhibit, so a naive union multiplies rows -- AEP's six CIKs carry the
+        # same 22 names for 132 rows. Worse, the extractions are not identical:
+        # on 68 of the 203 shared accessions the processor reports different row
+        # counts per CIK (Brixmor reads 619 under one CIK and 633 under the
+        # other from one `exhibit_url`). These are LLM parses of a single
+        # document with no basis for judging which is more faithful, so take one
+        # whole copy rather than merging -- a merge yields a list neither parse
+        # produced.
+        kept = []
+        for _, block in rows.groupby("accession_number", sort=False):
+            present = sorted(block["cik"].unique())
+            chosen = primary if primary in present else present[0]
+            copy = block[block["cik"] == chosen]
+            dropped_to_accession_collapse += len(block) - len(copy)
+            kept.append(copy)
+
+        surviving = pd.concat(kept)
+
+        # Surviving accessions are concatenated as-is: two registrants who filed
+        # separately both contribute in full, so a subsidiary named in both
+        # appears twice. Deduping that is deferred until a real multi-CIK
+        # company exists to reason against -- name alone over-merges genuinely
+        # distinct subsidiaries, and (name, jurisdiction) splits one subsidiary
+        # in two wherever a parse left the jurisdiction blank. Counting them is
+        # the evidence that decision needs.
+        if surviving["accession_number"].nunique() > 1:
+            names = [
+                text
+                for text in (_clean(value) for value in surviving["name"])
+                if text
+            ]
+            folded = Counter(name.casefold() for name in names)
+            duplicate_names_across_accessions += sum(
+                count - 1 for count in folded.values() if count > 1
+            )
+
         company["currentCorporateRelationships"] = [
             build_relationship(row, company)
-            for _, row in group.sort_values("name").iterrows()
+            for _, row in surviving.sort_values("name").iterrows()
         ]
         matched += 1
 
@@ -814,6 +866,18 @@ def attach_relationships(
         matched,
         len(companies),
         len(companies) - matched,
+    )
+    # Reported unconditionally so the collapse is visible rather than assumed --
+    # a silent 0 is itself the useful signal that no company is multi-registrant
+    # yet.
+    logger.info(
+        "%d companies joined more than one registrant; the accession collapse "
+        "dropped %d duplicate rows; %d duplicate child names survive across "
+        "separate accessions (not deduped -- see the join contract in "
+        "jobs/README.md).",
+        multi_registrant,
+        dropped_to_accession_collapse,
+        duplicate_names_across_accessions,
     )
 
 

--- a/jobs/build_dataset.py
+++ b/jobs/build_dataset.py
@@ -385,6 +385,85 @@ def normalize_cik(values: pd.Series) -> pd.Series:
 # ---------------------------------------------------------------------------
 
 
+def select_primary_cik(ciks: list[str]) -> str | None:
+    """Chooses the primary CIK for a company.
+
+    STUB, pending the company-facts processor. Lowest CIK is deterministic --
+    CIKs are zero-padded, so string order is numeric order -- but it is
+    demonstrably wrong for some registrant groups: it picks Entergy Arkansas
+    over Entergy Corp, and NSTAR Electric over Eversource Energy.
+
+    TODO: replace once company-facts lands. The replacement is the
+    accession-number prefix, which is the transmitting CIK. Across the 203
+    co-registrant accessions in corporate-structure it is one of the group's
+    own CIKs 140 times (69%), correctly naming the parent -- including the two
+    groups this stub gets wrong. The other 31% are agent-filed, where the
+    prefix belongs to the filing agent (mostly 0001047469, Toppan Merrill), so
+    it needs a guard: use the prefix only when it matches one of `ciks`.
+    Lowest CIK stays the terminal fallback, both for the agent-filed 31% and
+    for companies with no filing at all.
+
+    Do NOT reach for the SEC's <FILER> ordering. It looks like an exact
+    answer -- one block per co-registrant, apparently parent first, and it
+    holds for Huntsman, AEP and Brixmor -- but across 25 self-filed
+    co-registrant accessions the first block matches the transmitting CIK only
+    18 times (72%), and where it disagrees the real parent sits at position 2,
+    3, or 7 of 7 (Southern Co). The ordering is arbitrary, not hierarchical.
+
+    Args:
+        ciks: Every CIK rolling up to one PermID.
+
+    Returns:
+        The primary CIK, or `None` if the company has no CIK at all.
+    """
+    return min(ciks) if ciks else None
+
+
+def build_registrants(
+    group: pd.DataFrame, ciks: list[str], primary: str | None, company_as_of: str | None
+) -> list[dict]:
+    """Builds one Registrant per CIK rolling up to this PermID.
+
+    Each registrant is read off its own CIK's most recent row, so
+    `registrantName` is the name last reported against that CIK rather than the
+    PermID's name -- "Brixmor Operating Partnership LP" against a company named
+    "Brixmor Property Group Inc."
+
+    Args:
+        group: All source rows for a single PermID.
+        ciks: Every CIK for the PermID, already cleaned and de-duplicated.
+        primary: The CIK to mark primary, from `select_primary_cik`.
+        company_as_of: The company's observation date, used only as a floor when
+            a CIK's own rows carry no parseable stamp.
+
+    Returns:
+        Registrant dicts, primary first then ascending by CIK.
+    """
+    identifiers = group["identifier"].map(_clean)
+    is_cik = group["identifier_type"] == "cik"
+
+    registrants = []
+    for cik in ciks:
+        rows = group[is_cik & (identifiers == cik)]
+        newest = select_latest_snapshot(rows).iloc[0]
+        # A CIK whose rows carry no parseable stamp still has to appear --
+        # dropping a registrant over a missing date would lose the join key
+        # that a whole section depends on.
+        as_of = parse_last_processed(newest["last_processed"]) or company_as_of
+        registrants.append(
+            {
+                "sources": build_sources(_clean(newest["permid_url"]), as_of),
+                "asOf": as_of,
+                "cik": cik,
+                "registrantName": _clean(newest["entity_name"]),
+                "isPrimary": cik == primary,
+            }
+        )
+
+    registrants.sort(key=lambda r: (not r["isPrimary"], r["cik"]))
+    return registrants
+
+
 def select_latest_snapshot(group: pd.DataFrame) -> pd.DataFrame:
     """Reduces a PermID's rows to those of its most recent snapshot.
 
@@ -508,16 +587,8 @@ def transform_company(group: pd.DataFrame, logger: logging.Logger) -> dict:
     # here would drop a CIK that arrived from a different source.
     ciks = _collect(group.loc[group["identifier_type"] == "cik", "identifier"])
 
-    # Only claim a CIK when it is unambiguous. The data spec calls for Primary
-    # CIK selection logic but does not define it, and guessing a tie-break
-    # would silently attach the wrong filings to a company.
-    cik = ciks[0] if len(ciks) == 1 else None
-    if len(ciks) > 1:
-        logger.info(
-            "PermID %s has %d CIKs; leaving cik null pending primary-CIK logic.",
-            perm_id,
-            len(ciks),
-        )
+    primary_cik = select_primary_cik(ciks)
+    registrants = build_registrants(group, ciks, primary_cik, as_of)
 
     incorporated_country = _clean(first["incorporated_in"])
     hq_country = parse_address_country(first["hq_address"], logger)
@@ -543,7 +614,8 @@ def transform_company(group: pd.DataFrame, logger: logging.Logger) -> dict:
         "sources": sources,
         # Stable identifiers
         "permId": perm_id,
-        "cik": cik,
+        "cik": primary_cik,
+        "registrants": registrants,
         "ein": None,
         "lei": _clean(first["lei"]),
         # Core identity

--- a/jobs/fixtures/__init__.py
+++ b/jobs/fixtures/__init__.py
@@ -1,0 +1,25 @@
+"""Synthetic fixtures exercising `build_dataset` paths production data cannot.
+
+Run them with:
+
+    uv run python -m fixtures
+"""
+
+# Local imports
+from .harness import (
+    DEFAULT_COMPANY_ROW,
+    DEFAULT_STRUCTURE_ROW,
+    FixtureResult,
+    company_rows,
+    run_build,
+    structure_rows,
+)
+
+__all__ = [
+    "DEFAULT_COMPANY_ROW",
+    "DEFAULT_STRUCTURE_ROW",
+    "FixtureResult",
+    "company_rows",
+    "run_build",
+    "structure_rows",
+]

--- a/jobs/fixtures/__main__.py
+++ b/jobs/fixtures/__main__.py
@@ -1,0 +1,52 @@
+"""Runs every fixture case and reports pass/fail.
+
+    uv run python -m fixtures            # all cases
+    uv run python -m fixtures multi_cik  # cases whose name contains "multi_cik"
+
+Exits non-zero if any case fails, so it can gate a build.
+"""
+
+# Standard library imports
+import sys
+import traceback
+
+# Local imports
+from .cases import CASES
+
+
+def main(argv: list[str]) -> int:
+    """Runs the selected cases.
+
+    Args:
+        argv: Optional substrings; a case runs if its name contains any of them.
+
+    Returns:
+        0 if every selected case passed, 1 otherwise.
+    """
+    selected = [c for c in CASES if not argv or any(a in c.__name__ for a in argv)]
+    if not selected:
+        print(f"No fixture case matches {argv}. Known cases:")
+        for case in CASES:
+            print(f"  {case.__name__}")
+        return 1
+
+    failures: list[str] = []
+    for case in selected:
+        try:
+            case()
+        except Exception:  # noqa: BLE001 - a failing case must not stop the run
+            failures.append(case.__name__)
+            print(f"FAIL  {case.__name__}")
+            print(traceback.format_exc())
+        else:
+            print(f"ok    {case.__name__}")
+
+    print(f"\n{len(selected) - len(failures)}/{len(selected)} passed")
+    if failures:
+        print("Failed: " + ", ".join(failures))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/jobs/fixtures/cases.py
+++ b/jobs/fixtures/cases.py
@@ -347,6 +347,185 @@ def registrants_primary_is_lowest_cik_for_entergy() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Corporate structure -- union across CIKs, one extraction per accession
+# ---------------------------------------------------------------------------
+
+BRIXMOR_ACCESSION = "0001581068-17-000005"
+
+
+def _brixmor_rows(shared: int, only_holdco: int, only_opco: int) -> list[dict]:
+    """Two co-registrant extractions of one exhibit that disagree on row count.
+
+    Mirrors the real Brixmor shape: both CIKs are attributed accession
+    0001581068-17-000005, but the processor read a different set of names under
+    each. Scaled down from 619/633 -- the ratio is not what the collapse turns
+    on, the divergence is.
+    """
+    rows = []
+    for cik in ("1581068", "1630031"):
+        rows += [
+            {
+                "parent_cik": cik,
+                "accession_number": BRIXMOR_ACCESSION,
+                "name": f"Shared Sub {n} LLC",
+                "parent_name": "BRIXMOR",
+            }
+            for n in range(shared)
+        ]
+    rows += [
+        {
+            "parent_cik": "1581068",
+            "accession_number": BRIXMOR_ACCESSION,
+            "name": f"Holdco Only Sub {n} LLC",
+            "parent_name": "BRIXMOR",
+        }
+        for n in range(only_holdco)
+    ]
+    rows += [
+        {
+            "parent_cik": "1630031",
+            "accession_number": BRIXMOR_ACCESSION,
+            "name": f"Opco Only Sub {n} LLC",
+            "parent_name": "BRIXMOR",
+        }
+        for n in range(only_opco)
+    ]
+    return rows
+
+
+def structure_one_extraction_per_accession() -> None:
+    """Brixmor: both CIKs share one accession, so exactly one parse is kept.
+
+    The primary's copy wins. Merging the two would produce a list neither parse
+    returned -- the real-world version of that number is 634, which no
+    extraction of the exhibit ever contained.
+    """
+    result = run_build(
+        company_rows(
+            {"identifier": "0001581068", "entity_name": "BRIXMOR PROPERTY GROUP INC"},
+            {"identifier": "0001630031", "entity_name": "BRIXMOR OPERATING PTNSHP LP"},
+            COMPANION,
+        ),
+        structure_rows(*_brixmor_rows(shared=6, only_holdco=2, only_opco=4)),
+    )
+
+    record = result.by_permid("5000000001")
+    relationships = record["currentCorporateRelationships"]
+
+    # Primary is the lower CIK, 0001581068, whose parse holds 6 + 2 = 8 names.
+    assert record["cik"] == "0001581068", record["cik"]
+    assert len(relationships) == 8, (
+        f"expected the primary's 8-name parse, got {len(relationships)} "
+        "(12 would mean the two parses were merged, 10 the wrong copy)"
+    )
+    assert not any("Opco Only" in r["child"]["name"] for r in relationships), (
+        "rows from the non-chosen co-registrant's parse leaked in"
+    )
+    assert {r["disclosedByCik"] for r in relationships} == {"0001581068"}, (
+        "every row should be attributed to the registrant whose parse was kept"
+    )
+
+
+def structure_co_registrants_collapse_to_one_list() -> None:
+    """AEP: six CIKs carrying identical parses of one accession become one list.
+
+    This is the case the accession collapse exists for -- a naive union renders
+    132 rows describing 22 subsidiaries.
+    """
+    ciks = ("4904", "6879", "50172", "73986", "81027", "92487")
+    rows = [
+        {
+            "parent_cik": cik,
+            "accession_number": "0000004904-17-000019",
+            "name": f"AEP Subsidiary {n} LLC",
+            "parent_name": "AMERICAN ELECTRIC POWER CO INC",
+        }
+        for cik in ciks
+        for n in range(22)
+    ]
+    result = run_build(
+        company_rows(
+            *[
+                {"identifier": cik.zfill(10), "entity_name": f"AEP UNIT {cik}"}
+                for cik in ciks
+            ],
+            COMPANION,
+        ),
+        structure_rows(*rows, COMPANION_STRUCTURE),
+    )
+
+    relationships = result.by_permid("5000000001")["currentCorporateRelationships"]
+    assert len(relationships) == 22, (
+        f"expected 22 subsidiaries, got {len(relationships)} (132 means no collapse)"
+    )
+
+
+def structure_separate_filings_are_not_deduped() -> None:
+    """Two registrants filing separately both contribute, duplicates included.
+
+    Cross-accession dedup is deliberately deferred. This pins the current
+    behavior so adding it later is a visible change rather than a silent one.
+    """
+    rows = [
+        {
+            "parent_cik": "1581068",
+            "accession_number": "0001581068-17-000005",
+            "name": name,
+            "parent_name": "HOLDCO",
+        }
+        for name in ("Shared Sub LLC", "Holdco Only LLC")
+    ] + [
+        {
+            "parent_cik": "1630031",
+            "accession_number": "0001630031-17-000009",
+            "name": name,
+            "parent_name": "OPCO",
+        }
+        for name in ("Shared Sub LLC", "Opco Only LLC")
+    ]
+    result = run_build(
+        company_rows(
+            {"identifier": "0001581068", "entity_name": "HOLDCO"},
+            {"identifier": "0001630031", "entity_name": "OPCO"},
+            COMPANION,
+        ),
+        structure_rows(*rows),
+    )
+
+    relationships = result.by_permid("5000000001")["currentCorporateRelationships"]
+    names = [r["child"]["name"] for r in relationships]
+    assert len(relationships) == 4, f"expected 4 rows, got {len(relationships)}: {names}"
+    assert names.count("Shared Sub LLC") == 2, (
+        f"the subsidiary named in both filings should appear twice: {names}"
+    )
+
+    # Two distinct disclosing registrants, two distinct source documents, so the
+    # tree can be grouped by registrant from the record alone.
+    shared = [r for r in relationships if r["child"]["name"] == "Shared Sub LLC"]
+    assert {r["disclosedByCik"] for r in shared} == {
+        "0001581068",
+        "0001630031",
+    }, shared
+    assert len({r["sources"][0]["url"] for r in relationships}) >= 1
+    assert all(r["disclosedByCik"] for r in relationships), "missing disclosedByCik"
+
+
+def structure_disclosed_by_cik_matches_a_registrant() -> None:
+    """Every row's disclosedByCik resolves to one of the company's registrants."""
+    result = run_build(
+        company_rows({}, COMPANION),
+        structure_rows({}, COMPANION_STRUCTURE),
+    )
+
+    for record in result.records:
+        known = {r["cik"] for r in record["registrants"]}
+        for relationship in record["currentCorporateRelationships"]:
+            assert relationship["disclosedByCik"] in known, (
+                f"{relationship['disclosedByCik']} not in {known}"
+            )
+
+
 CASES = [
     smoke_single_cik,
     smoke_unmatched_cik_fails_the_build,
@@ -362,4 +541,8 @@ CASES = [
     registrants_survive_across_sources,
     registrants_primary_is_lowest_cik_for_aep,
     registrants_primary_is_lowest_cik_for_entergy,
+    structure_one_extraction_per_accession,
+    structure_co_registrants_collapse_to_one_list,
+    structure_separate_filings_are_not_deduped,
+    structure_disclosed_by_cik_matches_a_registrant,
 ]

--- a/jobs/fixtures/cases.py
+++ b/jobs/fixtures/cases.py
@@ -1,0 +1,68 @@
+"""Fixture cases for `build_dataset`.
+
+Each case is a function taking no arguments and raising `AssertionError` on
+failure. Register it in `CASES` and the runner picks it up -- no harness changes.
+
+Cases are grouped by the behavior they pin down. The multi-CIK cases exist
+because production data has no multi-CIK company, so nothing else exercises
+those paths.
+"""
+
+# Local imports
+from .harness import company_rows, run_build, structure_rows
+
+
+def smoke_single_cik() -> None:
+    """One PermID, one CIK, one filing: the ordinary shape, end to end."""
+    result = run_build(
+        company_rows({}),
+        structure_rows({}),
+    )
+
+    assert len(result.records) == 1, f"expected 1 record, got {len(result.records)}"
+    record = result.by_permid("5000000001")
+    assert record["name"] == "Fixture Co", record["name"]
+    assert record["cik"] == "0000000001", record["cik"]
+    assert record["hqCountry"] == "United States", record["hqCountry"]
+
+    relationships = record["currentCorporateRelationships"]
+    assert len(relationships) == 1, f"expected 1 relationship, got {len(relationships)}"
+    assert relationships[0]["child"]["name"] == "Fixture Subsidiary LLC"
+    assert relationships[0]["asOf"] == "2017-02-13", relationships[0]["asOf"]
+    assert relationships[0]["sources"], "relationship carries no source"
+
+
+def smoke_unmatched_cik_fails_the_build() -> None:
+    """A structure dataset that joins to nothing must fail, not render empty.
+
+    This guards the zero-match `RuntimeError` in `attach_relationships`. Without
+    it a padding mismatch looks exactly like "the processor has no data yet".
+    """
+    result = run_build(
+        company_rows({}),
+        structure_rows({"parent_cik": "9999999"}),
+        expect_failure=True,
+    )
+    assert result.records == [], "build should not have produced records"
+
+
+def smoke_warning_capture() -> None:
+    """The harness can assert on WARNINGs the build emits.
+
+    A company with no `permid_url` has no source citation, which `main` reports
+    as a WARNING. Cases that assert on the divergence guard rely on this
+    machinery working.
+    """
+    result = run_build(
+        company_rows({"permid_url": None}),
+        structure_rows({}),
+    )
+    matches = result.warnings_matching("no source citation")
+    assert matches, f"expected a source-citation WARNING, got {result.warnings()}"
+
+
+CASES = [
+    smoke_single_cik,
+    smoke_unmatched_cik_fails_the_build,
+    smoke_warning_capture,
+]

--- a/jobs/fixtures/cases.py
+++ b/jobs/fixtures/cases.py
@@ -511,6 +511,46 @@ def structure_separate_filings_are_not_deduped() -> None:
     assert all(r["disclosedByCik"] for r in relationships), "missing disclosedByCik"
 
 
+def structure_registrants_may_file_on_different_dates() -> None:
+    """Two registrants filing on different days give one record two `asOf`s.
+
+    This is the data precondition for the tree subtitle's filing range. Each row
+    keeps its own correct `asOf`; nothing is normalized to a single date.
+    """
+    rows = [
+        {
+            "parent_cik": "1581068",
+            "accession_number": "0001581068-17-000005",
+            "filing_date": "2017-02-13",
+            "name": "Holdco Sub LLC",
+            "parent_name": "HOLDCO",
+        },
+        {
+            "parent_cik": "1630031",
+            "accession_number": "0001630031-17-000009",
+            "filing_date": "2017-03-01",
+            "name": "Opco Sub LLC",
+            "parent_name": "OPCO",
+        },
+    ]
+    result = run_build(
+        company_rows(
+            {"identifier": "0001581068", "entity_name": "HOLDCO"},
+            {"identifier": "0001630031", "entity_name": "OPCO"},
+            COMPANION,
+        ),
+        structure_rows(*rows),
+    )
+
+    relationships = result.by_permid("5000000001")["currentCorporateRelationships"]
+    dates = {r["asOf"] for r in relationships}
+    assert dates == {"2017-02-13", "2017-03-01"}, dates
+
+    by_name = {r["child"]["name"]: r for r in relationships}
+    assert by_name["Holdco Sub LLC"]["asOf"] == "2017-02-13", by_name
+    assert by_name["Opco Sub LLC"]["asOf"] == "2017-03-01", by_name
+
+
 def structure_disclosed_by_cik_matches_a_registrant() -> None:
     """Every row's disclosedByCik resolves to one of the company's registrants."""
     result = run_build(
@@ -544,5 +584,6 @@ CASES = [
     structure_one_extraction_per_accession,
     structure_co_registrants_collapse_to_one_list,
     structure_separate_filings_are_not_deduped,
+    structure_registrants_may_file_on_different_dates,
     structure_disclosed_by_cik_matches_a_registrant,
 ]

--- a/jobs/fixtures/cases.py
+++ b/jobs/fixtures/cases.py
@@ -11,6 +11,32 @@ those paths.
 # Local imports
 from .harness import company_rows, run_build, structure_rows
 
+# A second, ordinary company whose CIK matches a structure row. Multi-CIK cases
+# need it: `attach_relationships` raises when the join matches nothing at all,
+# and a company under test may deliberately not match. Keeping that guard armed
+# is worth more than the two extra lines.
+COMPANION = {
+    "permid_id": "5000000002",
+    "permid_url": "https://permid.org/1-5000000002",
+    "identifier": "0000000002",
+    "standard_identifier": "Cik:0000000002",
+    "investor_name": "Companion Co",
+    "entity_name": "COMPANION CO",
+}
+COMPANION_STRUCTURE = {"parent_cik": "2", "name": "Companion Subsidiary LLC"}
+
+# Two snapshots of one PermID, taken by different sources at different times.
+OLDER = {
+    "input_source": "commercial_debt_tracker",
+    "last_processed": "20260101T000000",
+}
+NEWER = {
+    "input_source": "shareholder_tracker_cik",
+    "last_processed": "20260801T033040",
+}
+CANADA = "1 Older Street\nTORONTO\nONTARIO\nM5H 2N2\nCanada\n"
+USA = "1 Newer Street\nTESTVILLE\nDELAWARE\n19801\nUnited States\n"
+
 
 def smoke_single_cik() -> None:
     """One PermID, one CIK, one filing: the ordinary shape, end to end."""
@@ -61,8 +87,166 @@ def smoke_warning_capture() -> None:
     assert matches, f"expected a source-citation WARNING, got {result.warnings()}"
 
 
+# ---------------------------------------------------------------------------
+# Snapshot selection -- scalar fields come from the most recent row
+# ---------------------------------------------------------------------------
+
+
+def snapshot_newer_row_wins() -> None:
+    """Case 2: one CIK, two sources. The newer snapshot supplies the scalars."""
+    result = run_build(
+        company_rows(
+            {**OLDER, "hq_address": CANADA},
+            {**NEWER, "hq_address": USA},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    )
+
+    record = result.by_permid("5000000001")
+    assert record["hqCountry"] == "United States", record["hqCountry"]
+    assert record["sources"][0]["lastAccessed"] == "2026-08-01", record["sources"]
+    # The repeated CIK collapses: two rows, one identifier, one registrant.
+    assert record["cik"] == "0000000001", record["cik"]
+
+
+def snapshot_row_order_is_irrelevant() -> None:
+    """Reversing the fixture's row order changes nothing. Recency decides."""
+    forward = run_build(
+        company_rows(
+            {**OLDER, "hq_address": CANADA},
+            {**NEWER, "hq_address": USA},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    ).by_permid("5000000001")
+    reversed_ = run_build(
+        company_rows(
+            {**NEWER, "hq_address": USA},
+            {**OLDER, "hq_address": CANADA},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    ).by_permid("5000000001")
+
+    assert forward == reversed_, "row order changed the record"
+    assert forward["hqCountry"] == "United States", forward["hqCountry"]
+
+
+def snapshot_ticker_is_not_unioned_across_snapshots() -> None:
+    """Two snapshots reporting different tickers surface only the newer one."""
+    result = run_build(
+        company_rows(
+            {**OLDER, "ticker": "OLD", "exchange": "XNMS", "exchange_code": "NMS"},
+            {**NEWER, "ticker": "NEW", "exchange": "XNMS", "exchange_code": "NMS"},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    )
+
+    listing = result.by_permid("5000000001")["currentListing"] or {}
+    assert listing.get("ticker") == "NEW", listing
+    assert "OLD" not in repr(listing), listing
+
+
+def snapshot_fields_are_not_coalesced() -> None:
+    """A null in the newer snapshot wins over a value in the older one.
+
+    Coalescing field-by-field to the last non-null would assemble a record no
+    single fetch ever returned.
+    """
+    result = run_build(
+        company_rows(
+            {**OLDER, "ticker": "OLD", "exchange": "XNMS", "exchange_code": "NMS"},
+            {**NEWER, "ticker": None, "exchange": "XNMS", "exchange_code": "NMS"},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    )
+
+    listing = result.by_permid("5000000001")["currentListing"] or {}
+    assert not listing.get("ticker"), f"expected no ticker, got {listing.get('ticker')}"
+
+
+# ---------------------------------------------------------------------------
+# Divergence guard -- within a snapshot, not across snapshots
+# ---------------------------------------------------------------------------
+
+
+def divergence_identical_rows_of_one_snapshot_are_silent() -> None:
+    """Case 1: 3 CIKs, one source, identical fields. Expected shape, no WARNING.
+
+    This is the ordinary multi-CIK arrangement -- several registrants resolved
+    from a single `permid_data.json` -- so it must not be reported as an
+    anomaly.
+    """
+    result = run_build(
+        company_rows(
+            {"identifier": "0000000001", "entity_name": "FIXTURE CO A"},
+            {"identifier": "0000000003", "entity_name": "FIXTURE CO B"},
+            {"identifier": "0000000004", "entity_name": "FIXTURE CO C"},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    )
+
+    assert len(result.records) == 2, f"expected 2 records, got {len(result.records)}"
+    result.by_permid("5000000001")
+    divergence = result.warnings_matching("within one snapshot")
+    assert not divergence, f"unexpected divergence WARNING: {divergence}"
+
+
+def divergence_within_one_snapshot_warns() -> None:
+    """Rows of one snapshot disagreeing on a scalar raise a WARNING.
+
+    Those rows all came from a single `permid_data.json`, so disagreement is an
+    upstream anomaly. The build must still finish and still render the company:
+    an upstream disagreement is a signal to investigate, not a reason to drop a
+    page.
+    """
+    result = run_build(
+        company_rows(
+            {"identifier": "0000000001", "hq_address": USA},
+            {"identifier": "0000000003", "hq_address": CANADA},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    )
+
+    matches = result.warnings_matching("5000000001", "hq_address", "within one snapshot")
+    assert matches, f"expected a divergence WARNING, got {result.warnings()}"
+    record = result.by_permid("5000000001")
+    assert record["name"] == "Fixture Co", "company should still be rendered"
+
+
+def divergence_across_snapshots_is_silent() -> None:
+    """Two snapshots disagreeing is expected drift, not an anomaly.
+
+    Warning on this would fire for every company reached by more than one
+    source, which is noise rather than signal.
+    """
+    result = run_build(
+        company_rows(
+            {**OLDER, "hq_address": CANADA},
+            {**NEWER, "hq_address": USA},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    )
+
+    divergence = result.warnings_matching("within one snapshot")
+    assert not divergence, f"cross-snapshot drift should be silent: {divergence}"
+
+
 CASES = [
     smoke_single_cik,
     smoke_unmatched_cik_fails_the_build,
     smoke_warning_capture,
+    snapshot_newer_row_wins,
+    snapshot_row_order_is_irrelevant,
+    snapshot_ticker_is_not_unioned_across_snapshots,
+    snapshot_fields_are_not_coalesced,
+    divergence_identical_rows_of_one_snapshot_are_silent,
+    divergence_within_one_snapshot_warns,
+    divergence_across_snapshots_is_silent,
 ]

--- a/jobs/fixtures/cases.py
+++ b/jobs/fixtures/cases.py
@@ -238,6 +238,115 @@ def divergence_across_snapshots_is_silent() -> None:
     assert not divergence, f"cross-snapshot drift should be silent: {divergence}"
 
 
+# ---------------------------------------------------------------------------
+# Registrants -- every CIK survives, exactly one is primary
+# ---------------------------------------------------------------------------
+
+
+def registrants_three_ciks_one_source() -> None:
+    """Case 1: three CIKs under one source become three registrants."""
+    result = run_build(
+        company_rows(
+            {"identifier": "0000000004", "entity_name": "FIXTURE CO C"},
+            {"identifier": "0000000001", "entity_name": "FIXTURE CO A"},
+            {"identifier": "0000000003", "entity_name": "FIXTURE CO B"},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    )
+
+    record = result.by_permid("5000000001")
+    registrants = record["registrants"]
+    assert len(registrants) == 3, f"expected 3 registrants, got {len(registrants)}"
+
+    primaries = [r for r in registrants if r["isPrimary"]]
+    assert len(primaries) == 1, f"expected exactly 1 primary, got {len(primaries)}"
+    assert registrants[0]["isPrimary"], "registrants must be sorted primary-first"
+    assert record["cik"] == registrants[0]["cik"] == "0000000001", record["cik"]
+
+    # registrantName is the name reported against that CIK, not the PermID name.
+    by_cik = {r["cik"]: r for r in registrants}
+    assert by_cik["0000000003"]["registrantName"] == "FIXTURE CO B", by_cik
+    assert record["name"] == "Fixture Co", record["name"]
+    assert all(r["sources"] for r in registrants), "registrant missing a citation"
+
+
+def registrants_survive_across_sources() -> None:
+    """Case 3: CIK A from one source, CIK B from another. Both survive.
+
+    This is the case where filtering identifiers by recency -- rather than only
+    field values -- would silently drop a registrant.
+    """
+    result = run_build(
+        company_rows(
+            {**OLDER, "identifier": "0000000001", "entity_name": "FIXTURE CO A"},
+            {**NEWER, "identifier": "0000000003", "entity_name": "FIXTURE CO B"},
+            COMPANION,
+        ),
+        structure_rows({}, COMPANION_STRUCTURE),
+    )
+
+    registrants = result.by_permid("5000000001")["registrants"]
+    assert {r["cik"] for r in registrants} == {"0000000001", "0000000003"}, registrants
+
+
+def registrants_primary_is_lowest_cik_for_aep() -> None:
+    """The AEP group: lowest CIK happens to be right."""
+    result = run_build(
+        company_rows(
+            *[
+                {"identifier": cik, "entity_name": f"AEP UNIT {cik}"}
+                for cik in (
+                    "0000004904",
+                    "0000006879",
+                    "0000050172",
+                    "0000073986",
+                    "0000081027",
+                    "0000092487",
+                )
+            ],
+            COMPANION,
+        ),
+        structure_rows({"parent_cik": "4904"}, COMPANION_STRUCTURE),
+    )
+
+    record = result.by_permid("5000000001")
+    assert record["cik"] == "0000004904", record["cik"]
+    assert len(record["registrants"]) == 6, len(record["registrants"])
+
+
+def registrants_primary_is_lowest_cik_for_entergy() -> None:
+    """The Entergy group: lowest CIK is WRONG, and asserted anyway.
+
+    0000007323 is Entergy Arkansas; the real parent is Entergy Corp
+    (0000065984). Pinning the wrong answer makes replacing `select_primary_cik`
+    a visible, deliberate diff rather than a silent behavior change.
+    """
+    result = run_build(
+        company_rows(
+            *[
+                {"identifier": cik, "entity_name": f"ENTERGY UNIT {cik}"}
+                for cik in (
+                    "0000065984",
+                    "0000007323",
+                    "0000044570",
+                    "0000055259",
+                    "0000071508",
+                    "0000202584",
+                    "0001999371",
+                )
+            ],
+            COMPANION,
+        ),
+        structure_rows({"parent_cik": "65984"}, COMPANION_STRUCTURE),
+    )
+
+    record = result.by_permid("5000000001")
+    assert record["cik"] == "0000007323", (
+        f"expected the documented-wrong stub answer 0000007323, got {record['cik']}"
+    )
+
+
 CASES = [
     smoke_single_cik,
     smoke_unmatched_cik_fails_the_build,
@@ -249,4 +358,8 @@ CASES = [
     divergence_identical_rows_of_one_snapshot_are_silent,
     divergence_within_one_snapshot_warns,
     divergence_across_snapshots_is_silent,
+    registrants_three_ciks_one_source,
+    registrants_survive_across_sources,
+    registrants_primary_is_lowest_cik_for_aep,
+    registrants_primary_is_lowest_cik_for_entergy,
 ]

--- a/jobs/fixtures/cases.py
+++ b/jobs/fixtures/cases.py
@@ -566,6 +566,66 @@ def structure_disclosed_by_cik_matches_a_registrant() -> None:
             )
 
 
+def structure_same_day_filings_break_on_report_date() -> None:
+    """Two 10-Ks filed the same day: the later fiscal period wins, not the
+    higher accession.
+
+    Modeled on DOC DR, LLC (CIK 1583994), which filed its FY2014 and FY2016
+    10-Ks on 2017-02-24 through different filer agents. The accessions are
+    arranged as they are in production -- the FY2014 one sorts higher -- so this
+    case fails if accession number is the tie-break.
+    """
+    rows = [
+        {
+            "accession_number": "0001583994-17-000009",
+            "filing_date": "2017-02-24",
+            "report_date": "2014-12-31",
+            "name": "Stale Period Sub LLC",
+        },
+        {
+            "accession_number": "0001574540-17-000007",
+            "filing_date": "2017-02-24",
+            "report_date": "2016-12-31",
+            "name": "Latest Period Sub LLC",
+        },
+    ]
+    result = run_build(company_rows({}), structure_rows(*rows))
+
+    relationships = result.by_permid("5000000001")["currentCorporateRelationships"]
+    names = [r["child"]["name"] for r in relationships]
+    assert names == ["Latest Period Sub LLC"], (
+        f"expected only the FY2016 filing's subsidiary, got {names}"
+    )
+
+
+def structure_same_day_filings_without_report_date_still_resolve() -> None:
+    """A blank `report_date` falls through to the accession tie-break.
+
+    Seven 20FR12B rows carry no `report_date`. Comparing a null against itself
+    is false, so a group with nothing to compare must fall through rather than
+    match no row at all and cost the company its tree.
+    """
+    rows = [
+        {
+            "accession_number": "0000000001-17-000005",
+            "report_date": None,
+            "name": "Lower Accession Sub LLC",
+        },
+        {
+            "accession_number": "0000000001-17-000009",
+            "report_date": None,
+            "name": "Higher Accession Sub LLC",
+        },
+    ]
+    result = run_build(company_rows({}), structure_rows(*rows))
+
+    relationships = result.by_permid("5000000001")["currentCorporateRelationships"]
+    names = [r["child"]["name"] for r in relationships]
+    assert names == ["Higher Accession Sub LLC"], (
+        f"expected the highest accession to win, got {names}"
+    )
+
+
 CASES = [
     smoke_single_cik,
     smoke_unmatched_cik_fails_the_build,
@@ -585,5 +645,7 @@ CASES = [
     structure_co_registrants_collapse_to_one_list,
     structure_separate_filings_are_not_deduped,
     structure_registrants_may_file_on_different_dates,
+    structure_same_day_filings_break_on_report_date,
+    structure_same_day_filings_without_report_date_still_resolve,
     structure_disclosed_by_cik_matches_a_registrant,
 ]

--- a/jobs/fixtures/harness.py
+++ b/jobs/fixtures/harness.py
@@ -71,6 +71,7 @@ DEFAULT_COMPANY_ROW: dict[str, Any] = {
 DEFAULT_STRUCTURE_ROW: dict[str, Any] = {
     "parent_cik": "1",
     "filing_date": "2017-02-13",
+    "report_date": "2016-12-31",
     "form_type": "10-K",
     "exhibit_type": "EX-21",
     "accession_number": "0000000001-17-000001",

--- a/jobs/fixtures/harness.py
+++ b/jobs/fixtures/harness.py
@@ -1,0 +1,252 @@
+"""Machinery for running `build_dataset` against synthetic inputs.
+
+No PermID in production carries more than one CIK, so the multi-CIK paths in
+`build_dataset` cannot be exercised against real data at all. These fixtures are
+not a supplement to production coverage -- they are the only coverage those code
+paths will ever have.
+
+A case declares only the columns it cares about; `DEFAULT_COMPANY_ROW` and
+`DEFAULT_STRUCTURE_ROW` fill in the rest, so adding a case costs a few lines and
+never touches this module.
+
+The build is exercised end to end -- `build_dataset.main` is called with real
+parquet files on disk, not by poking individual transform functions -- because
+the bugs worth catching here live in how the stages compose.
+"""
+
+# Standard library imports
+import contextlib
+import importlib.util
+import io
+import json
+import logging
+import os
+import tempfile
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Third-party imports
+import pandas as pd
+
+JOBS_DIR = Path(__file__).resolve().parent.parent
+
+# Every column `build_dataset` reads off a company-info row, plus the ones that
+# define the grain. Values mirror the shape of production data -- `hq_address`
+# is a newline-delimited block ending in a country, `last_processed` is compact
+# basic ISO -- because the parsers care about both.
+DEFAULT_COMPANY_ROW: dict[str, Any] = {
+    "input_source": "shareholder_tracker_cik",
+    "entity_name": "FIXTURE CO",
+    "identifier_type": "cik",
+    "identifier": "0000000001",
+    "standard_identifier": "Cik:0000000001",
+    "permid_url": "https://permid.org/1-5000000001",
+    "investor_name": "Fixture Co",
+    "permid_id": "5000000001",
+    "hq_address": "1 Test Street\nTESTVILLE\nDELAWARE\n19801\nUnited States\n",
+    "registered_address": None,
+    "fax_number": None,
+    "phone_number": None,
+    "lei": None,
+    "founded_date": None,
+    "incorporated_in": "United States",
+    "domiciled_in": "United States",
+    "url": None,
+    "activity_status": "tr-org:statusActive",
+    "primary_business_sector_label": None,
+    "primary_economic_sector_label": None,
+    "primary_industry_group_label": None,
+    "primary_business_sector_comment": None,
+    "primary_economic_sector_comment": None,
+    "primary_industry_group_comment": None,
+    "ticker": None,
+    "exchange": None,
+    "exchange_code": None,
+    "ric": None,
+    "last_processed": "20260801T033040",
+}
+
+DEFAULT_STRUCTURE_ROW: dict[str, Any] = {
+    "parent_cik": "1",
+    "filing_date": "2017-02-13",
+    "form_type": "10-K",
+    "exhibit_type": "EX-21",
+    "accession_number": "0000000001-17-000001",
+    "exhibit_url": "https://www.sec.gov/Archives/fixture/ex21.htm",
+    "name": "Fixture Subsidiary LLC",
+    "location": "Delaware",
+    "parent_name": "FIXTURE CO",
+    "parent_state_of_incorporation": "DE",
+    "parent_business_street1": None,
+    "parent_business_street2": None,
+    "parent_business_city": None,
+    "parent_business_state": None,
+    "parent_business_zip": None,
+    "parent_business_country": None,
+    "parent_business_country_code": None,
+    "parent_tickers": None,
+    "parent_exchanges": None,
+    "source_quote": None,
+    "date_added": "2026-08-01",
+}
+
+
+def _load_build_dataset():
+    """Imports `build_dataset` by path.
+
+    `jobs/` is not an installed package and the fixture runner may be invoked
+    from either `jobs/` or the repo root, so a plain import is not reliable.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "build_dataset", JOBS_DIR / "build_dataset.py"
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - import guard
+        raise RuntimeError(f"Could not import build_dataset.py from {JOBS_DIR}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def rows(defaults: dict[str, Any], overrides: Iterable[dict[str, Any]]) -> pd.DataFrame:
+    """Expands partial row dicts into a full DataFrame.
+
+    Args:
+        defaults: `DEFAULT_COMPANY_ROW` or `DEFAULT_STRUCTURE_ROW`.
+        overrides: One dict per row, holding only the columns that differ.
+
+    Returns:
+        A DataFrame with every column the production schema carries.
+
+    Raises:
+        `KeyError` if an override names a column the schema does not have --
+        a typo would otherwise be silently ignored and the assertion it was
+        meant to drive would pass for the wrong reason.
+    """
+    built = []
+    for override in overrides:
+        unknown = set(override) - set(defaults)
+        if unknown:
+            raise KeyError(
+                f"Unknown fixture column(s) {sorted(unknown)}. "
+                f"Known columns: {sorted(defaults)}"
+            )
+        built.append({**defaults, **override})
+    return pd.DataFrame(built, columns=list(defaults))
+
+
+def company_rows(*overrides: dict[str, Any]) -> pd.DataFrame:
+    """Builds a company-info fixture frame from partial rows."""
+    return rows(DEFAULT_COMPANY_ROW, overrides)
+
+
+def structure_rows(*overrides: dict[str, Any]) -> pd.DataFrame:
+    """Builds a corporate-structure fixture frame from partial rows."""
+    return rows(DEFAULT_STRUCTURE_ROW, overrides)
+
+
+@dataclass
+class FixtureResult:
+    """The output of one build run, plus everything the build said while running."""
+
+    records: list[dict]
+    log: list[logging.LogRecord] = field(default_factory=list)
+
+    def by_permid(self, perm_id: str) -> dict:
+        """Returns the single record for a PermID.
+
+        Raises:
+            `AssertionError` if there is not exactly one.
+        """
+        matches = [r for r in self.records if r["permId"] == perm_id]
+        if len(matches) != 1:
+            raise AssertionError(
+                f"Expected exactly one record for PermID {perm_id}, got {len(matches)}"
+            )
+        return matches[0]
+
+    def messages(self, level: int) -> list[str]:
+        """Returns rendered log messages at exactly `level`."""
+        return [r.getMessage() for r in self.log if r.levelno == level]
+
+    def warnings(self) -> list[str]:
+        """Returns rendered WARNING messages."""
+        return self.messages(logging.WARNING)
+
+    def warnings_matching(self, *needles: str) -> list[str]:
+        """Returns WARNINGs containing every one of `needles`."""
+        return [m for m in self.warnings() if all(n in m for n in needles)]
+
+
+class _Capture(logging.Handler):
+    """Collects log records so a fixture can assert on what the build reported."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def run_build(
+    companies: pd.DataFrame, structure: pd.DataFrame, *, expect_failure: bool = False
+) -> FixtureResult:
+    """Runs the whole `build_dataset` pipeline against two in-memory frames.
+
+    Args:
+        companies: A company-info frame, from `company_rows`.
+        structure: A corporate-structure frame, from `structure_rows`.
+        expect_failure: When true, a `RuntimeError` from the build is caught and
+            recorded rather than raised -- for cases asserting the build refuses
+            bad input.
+
+    Returns:
+        A `FixtureResult` holding the emitted records and captured log.
+    """
+    build_dataset = _load_build_dataset()
+    capture = _Capture()
+    logger = logging.getLogger("FIXTURE BUILD")
+    logger.setLevel(logging.DEBUG)
+    logger.handlers = [capture]
+    logger.propagate = False
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        company_path = tmpdir / "company_info.parquet"
+        structure_path = tmpdir / "corporate_structure.parquet"
+        output_path = tmpdir / "companies.json"
+        companies.to_parquet(company_path, index=False)
+        structure.to_parquet(structure_path, index=False)
+
+        previous = {
+            key: os.environ.get(key)
+            for key in (
+                "COMPANY_INFO_FILE_PATH",
+                "CORPORATE_STRUCTURE_FILE_PATH",
+                "OUTPUT_FILE_PATH",
+            )
+        }
+        os.environ["COMPANY_INFO_FILE_PATH"] = str(company_path)
+        os.environ["CORPORATE_STRUCTURE_FILE_PATH"] = str(structure_path)
+        os.environ["OUTPUT_FILE_PATH"] = str(output_path)
+        try:
+            # The build prints nothing to stdout, but pandas and pyarrow may;
+            # swallow it so the runner's own output stays readable.
+            with contextlib.redirect_stdout(io.StringIO()):
+                build_dataset.main(logger)
+        except RuntimeError:
+            if not expect_failure:
+                raise
+            return FixtureResult(records=[], log=capture.records)
+        finally:
+            for key, value in previous.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+        records = json.loads(output_path.read_text(encoding="utf-8"))
+
+    return FixtureResult(records=records, log=capture.records)

--- a/web/src/app/companies/[id]/page.tsx
+++ b/web/src/app/companies/[id]/page.tsx
@@ -103,8 +103,8 @@ const CompanyPage = async ({ params }: CompanyPageParams) => {
     );
   }
 
-  // Tree, Holders, and Debt have no processor yet; everything else on this
-  // page is real. See mock-sections.ts.
+  // Holders and Debt have no processor yet; everything else on this page is
+  // real. See mock-sections.ts.
   const mock = getMockSections(company);
 
   return (
@@ -127,7 +127,7 @@ const CompanyPage = async ({ params }: CompanyPageParams) => {
           <CompanyTabs companyName={company.name} />
           <div className="flex flex-col gap-4">
             <CompanyOverviewSection company={company} />
-            <CompanyTreeSection tree={mock.tree} source={mock.treeSource} />
+            <CompanyTreeSection company={company} />
             <CompanyShareholdersSection
               shareholders={mock.shareholders}
               source={mock.shareholdersSource}

--- a/web/src/app/downloads/page.tsx
+++ b/web/src/app/downloads/page.tsx
@@ -16,7 +16,7 @@ const DATASETS = [
   {
     name: "Corporate structures",
     description:
-      "Parent–subsidiary edges from GLEIF and SEC Exhibit 21 filings, normalized to a directed ownership graph.",
+      "Parent–subsidiary relationships as disclosed in SEC Exhibit 21 and Exhibit 8 subsidiary lists, taken from each registrant's most recent 10-K or 20-F.",
     size: "128 MB",
     rows: "4.2M",
     updated: "Jul 6, 2026",

--- a/web/src/app/methodology/page.tsx
+++ b/web/src/app/methodology/page.tsx
@@ -49,7 +49,7 @@ export default function MethodologyPage() {
             </Article.Body.Section.Paragraph>
             <Article.Body.Section.Paragraph>
               In practice, company facts are derived from LSEG PermID; corporate
-              trees are reconciled from GLEIF and SEC Exhibit&nbsp;21 subsidiary
+              trees come from SEC Exhibit&nbsp;21 and Exhibit&nbsp;8 subsidiary
               lists attached to 10-K and 20-F filings; institutional
               shareholders come from SEC Form&nbsp;13-F filings, augmented by
               13-D and 13-G beneficial-ownership disclosures; and commercial
@@ -65,11 +65,14 @@ export default function MethodologyPage() {
               Building the corporate tree
             </Article.Body.Section.Title>
             <Article.Body.Section.Paragraph>
-              Parent&ndash;subsidiary relationships are extracted, normalized to
-              a single entity per legal person, and merged into a directed
-              ownership graph. Conflicting disclosures are resolved in favor of
-              the most recent primary filing, and unresolved conflicts are
-              flagged for manual review.
+              Parent&ndash;subsidiary relationships are extracted from the
+              subsidiary list a registrant attaches to its own annual report,
+              and are presented as that filing discloses them. Where a company
+              has filed more than once, only its most recent filing is shown,
+              with the filing date alongside. Subsidiary names are reproduced as
+              filed and are not resolved to company records, so a subsidiary
+              that is itself a registrant elsewhere in the database is not yet
+              linked to it.
             </Article.Body.Section.Paragraph>
           </Article.Body.Section>
 

--- a/web/src/blocks/index.ts
+++ b/web/src/blocks/index.ts
@@ -2,5 +2,6 @@ export { Article } from "./article";
 export { Footer } from "./footer";
 export { InfoButton } from "./info-button";
 export { Navbar } from "./navbar";
+export { SourceCitation } from "./source-citation";
 export { Statistic, StatisticGrid } from "./statistic";
 export { ThemeToggle } from "./theme-toggle";

--- a/web/src/blocks/source-citation.tsx
+++ b/web/src/blocks/source-citation.tsx
@@ -4,8 +4,13 @@ type SourceCitationProps = {
   source: Source;
   /**
    * How this source was dated, in the wording that fits the fact being cited —
-   * e.g. `"filed 2017-02-13, retrieved 2026-08-03"` for a filing, or
+   * e.g. `"filed on 2017-02-13, retrieved 2026-08-03"` for a filing, or
    * `"last accessed 2026-08-01"` for a record that reports no filing date.
+   *
+   * Name the kind of date. A filing's date is the day it reached EDGAR, not the
+   * fiscal period it covers — the two differ by a median of 58 days, and 113 of
+   * the 134 companies with a corporate tree filed in a different year than they
+   * report on. A bare date invites the reader to assume the wrong one.
    */
   detail?: string;
 };

--- a/web/src/blocks/source-citation.tsx
+++ b/web/src/blocks/source-citation.tsx
@@ -1,0 +1,37 @@
+import type { Source } from "@/types/domain";
+
+type SourceCitationProps = {
+  source: Source;
+  /**
+   * How this source was dated, in the wording that fits the fact being cited —
+   * e.g. `"filed 2017-02-13, retrieved 2026-08-03"` for a filing, or
+   * `"last accessed 2026-08-01"` for a record that reports no filing date.
+   */
+  detail?: string;
+};
+
+/**
+ * A citation for one {@link Source}, rendered as the source's name linked to the
+ * document it came from.
+ *
+ * The URL is deliberately not printed as text. SEC Archives URLs run past a
+ * hundred characters and wrap across several lines of a source footer, which
+ * buries the name that actually tells a reader what the citation is. The
+ * destination stays reachable through the link and its `title`.
+ */
+export function SourceCitation({ source, detail }: SourceCitationProps) {
+  return (
+    <>
+      <a
+        href={source.url}
+        title={source.url}
+        className="underline hover:text-foreground"
+        target="_blank"
+        rel="noreferrer"
+      >
+        {source.name}
+      </a>
+      {detail ? ` (${detail})` : null}.
+    </>
+  );
+}

--- a/web/src/components/hero-globe.tsx
+++ b/web/src/components/hero-globe.tsx
@@ -336,5 +336,3 @@ export function HeroGlobe() {
     />
   );
 }
-
-export default HeroGlobe;

--- a/web/src/domains/companies/blocks/company-overview-section.tsx
+++ b/web/src/domains/companies/blocks/company-overview-section.tsx
@@ -1,51 +1,109 @@
 import { SectionCard } from "@/blocks/section-card";
-import type { Company, Source } from "@/types/domain";
+import { cn } from "@/lib/utils";
+import type { Company, CurrentCorporateRelationship, Source } from "@/types/domain";
 
 type CompanyOverviewSectionProps = {
   company: Company;
 };
 
-type Fact = {
-  label: string;
-  value: string;
+/**
+ * One headline stat, linking to the section that carries the detail. `value` is
+ * null when the fact has no processor yet — those render an explicit unavailable
+ * state rather than a fabricated figure.
+ */
+type Gateway = {
+  href: string;
+  kicker: string;
+  value: string | null;
+  unit: string;
+  meta: string;
+  link: string;
 };
 
-/**
- * Collect the facts the company-info dataset actually supports. Anything not
- * derivable from a cited source is omitted rather than filled in — an
- * uncited claim on a company page is worse than a missing one.
- */
-function collectFacts(company: Company): Fact[] {
-  const facts: Fact[] = [];
-
-  if (company.currentIndustry) {
-    const broader = company.currentSectors.map((s) => s.name).join(" · ");
-    facts.push({
-      label: "Classification",
-      value: broader
-        ? `${company.currentIndustry.name} (${broader})`
-        : company.currentIndustry.name,
-    });
-  }
-
-  if (company.hqCountry) {
-    const sameCountry = company.hqCountry === company.incorporatedCountry;
-    facts.push({
-      label: "Location",
-      value:
-        sameCountry || !company.incorporatedCountry
-          ? `Headquartered in ${company.hqCountry}.`
-          : `Headquartered in ${company.hqCountry}; incorporated in ${company.incorporatedCountry}.`,
-    });
-  }
-
-  const ticker = company.currentListing?.ticker;
-  if (ticker) {
-    facts.push({ label: "Listing", value: `Trades as ${ticker}.` });
-  }
-
-  return facts;
+function plural(count: number, word: string): string {
+  return `${count} ${word}${count === 1 ? "" : "s"}`;
 }
+
+/**
+ * How many distinct jurisdictions a company's subsidiaries are incorporated in.
+ *
+ * Case-folded, because the source is inconsistent about it — "Delaware" and
+ * "DELAWARE" are one jurisdiction, not two. Blanks are excluded rather than
+ * counted as an unknown jurisdiction. This is still an overcount: "DE" and
+ * "Delaware" remain separate values, and merging those needs a state
+ * abbreviation crosswalk that does not exist here. Hence "jurisdictions" rather
+ * than "countries" — the looser word is the true one, and `location` genuinely
+ * mixes states with countries.
+ */
+function countJurisdictions(
+  relationships: CurrentCorporateRelationship[],
+): number {
+  const seen = new Set<string>();
+  for (const relationship of relationships) {
+    const jurisdiction = relationship.childJurisdiction?.trim();
+    if (jurisdiction) seen.add(jurisdiction.toLowerCase());
+  }
+  return seen.size;
+}
+
+/**
+ * The Corporate Tree stat. This is the only gateway with real data behind it.
+ *
+ * The count is subsidiaries, excluding the registrant — deliberately one less
+ * than the Corporate Tree section's own "N entities" subtitle, which includes
+ * it. The two numbers sit a few inches apart on the page and look like they
+ * should match; they should not.
+ */
+function treeGateway(company: Company): Gateway {
+  const relationships = company.currentCorporateRelationships;
+  const base = {
+    href: "#tree",
+    kicker: "Corporate Tree",
+    unit: "Subsidiaries traced",
+    link: "View corporate tree",
+  };
+
+  if (relationships.length === 0) {
+    return {
+      ...base,
+      value: "0",
+      meta: "No Exhibit 21 or Exhibit 8 subsidiary list in scope",
+    };
+  }
+
+  const [first] = relationships;
+  const jurisdictions = countJurisdictions(relationships);
+  const citation = first.sources[0]?.name ?? "SEC filing";
+  return {
+    ...base,
+    value: String(relationships.length),
+    meta: `${plural(jurisdictions, "jurisdiction")} · ${citation} · filed ${first.asOf}`,
+  };
+}
+
+/**
+ * The two stats whose processors do not exist yet. They render unavailable
+ * rather than showing the sample figures the sections below still display — a
+ * fabricated number in a headline stat is worse than an absent one.
+ */
+const PENDING_GATEWAYS: Gateway[] = [
+  {
+    href: "#holders",
+    kicker: "Shareholders",
+    value: null,
+    unit: "Shareholders disclosed",
+    meta: "Awaiting the shareholder-tracker processor · sample data shown below",
+    link: "View shareholders",
+  },
+  {
+    href: "#debt",
+    kicker: "Commercial Debt",
+    value: null,
+    unit: "Outstanding debt",
+    meta: "Awaiting the CDT processor · sample data shown below",
+    link: "View commercial debt",
+  },
+];
 
 function formatSource(sources: Source[]): string | undefined {
   if (sources.length === 0) return undefined;
@@ -53,66 +111,76 @@ function formatSource(sources: Source[]): string | undefined {
   return `${source.name} — ${source.url} (last accessed ${source.lastAccessed}).`;
 }
 
-function FactList({ facts }: { facts: Fact[] }) {
-  if (facts.length === 0) {
-    return (
-      <p className="text-sm text-muted leading-relaxed m-0">
-        No sourced overview is available for this company yet. A narrative
-        description requires the company-facts processor, which extracts it from
-        the registrant&apos;s own 10-K.
-      </p>
-    );
-  }
+function GatewayCard({ gateway }: { gateway: Gateway }) {
+  const unavailable = gateway.value === null;
   return (
-    <ul className="flex flex-col gap-3 list-none m-0 p-0">
-      {facts.map((fact) => (
-        <li key={fact.label} className="flex items-start gap-3">
-          <span aria-hidden className="mt-1.5 inline-block size-2 shrink-0 bg-muted" />
-          <p className="text-sm text-foreground leading-relaxed m-0">
-            <span className="font-semibold">{fact.label}.</span>{" "}
-            <span className="text-muted">{fact.value}</span>
-          </p>
-        </li>
+    <a
+      href={gateway.href}
+      className="group flex flex-col gap-1 p-4 md:p-6 hover:bg-overlay/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+    >
+      <span className="font-mono text-[10px] uppercase tracking-wider text-muted">
+        {gateway.kicker}
+      </span>
+      <span
+        className={cn(
+          "font-inter-tight tracking-tight",
+          unavailable
+            ? "text-lg md:text-xl font-medium text-muted"
+            : "text-3xl md:text-4xl font-semibold text-foreground",
+        )}
+      >
+        {unavailable ? "Not available" : gateway.value}
+      </span>
+      <span className="text-sm text-foreground">{gateway.unit}</span>
+      <span className="font-mono text-[10px] text-muted leading-relaxed">
+        {gateway.meta}
+      </span>
+      <span className="mt-2 font-mono text-[10px] uppercase tracking-wider text-primary">
+        {gateway.link} →
+      </span>
+    </a>
+  );
+}
+
+function Gateways({ gateways }: { gateways: Gateway[] }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-muted/15 -m-4 md:-m-6">
+      {gateways.map((gateway) => (
+        <GatewayCard key={gateway.href} gateway={gateway} />
       ))}
-    </ul>
+    </div>
   );
 }
 
 /**
- * The "Overview" section of the company detail page.
+ * The "Overview" section of the company detail page — headline counts that
+ * gateway into the sections below.
  *
- * Every fact here is derived from the company-info dataset and cites its
- * source. The section is deliberately thin: the fuller narrative description
- * the design calls for depends on the company-facts processor, so until that
- * exists the section says as much rather than inventing prose.
+ * Only the Corporate Tree stat has a processor behind it. The other two say so
+ * rather than repeating the sample figures their sections display.
+ *
+ * There is no section-level date: the three stats draw on datasets with
+ * genuinely different vintages — corporate structure is 2016–2018, company info
+ * is current — so each card carries its own instead of one date that would be
+ * wrong for at least one of them.
  */
 export function CompanyOverviewSection({ company }: CompanyOverviewSectionProps) {
-  const facts = collectFacts(company);
-  const source = formatSource(company.sources);
-  const asOf = company.currentIndustry?.asOf ?? company.sources[0]?.lastAccessed;
+  const gateways = [treeGateway(company), ...PENDING_GATEWAYS];
 
   return (
     <SectionCard
       id="overview"
       title="Overview"
-      subtitle={asOf ? `Company info · as of ${asOf}` : "Company info"}
-      info="Identity, classification, and listing details resolved from LSEG PermID. Financial figures and a narrative description require the company-facts processor and are not yet available."
-      source={source}
+      subtitle="Headline counts"
+      info="Headline counts for the sections below. Only the corporate tree is sourced from a processor today; shareholder and commercial-debt figures require the shareholder-tracker and CDT processors and are shown as unavailable rather than estimated."
+      source={formatSource(company.sources)}
       expanded={
-        <div className="max-w-3xl mx-auto text-base">
-          <FactList facts={facts} />
-          {source ? (
-            <p className="mt-8 text-xs text-muted leading-relaxed">
-              <span className="font-mono uppercase tracking-wider font-medium mr-2">
-                Source.
-              </span>
-              {source}
-            </p>
-          ) : null}
+        <div className="max-w-3xl mx-auto">
+          <Gateways gateways={gateways} />
         </div>
       }
     >
-      <FactList facts={facts} />
+      <Gateways gateways={gateways} />
     </SectionCard>
   );
 }

--- a/web/src/domains/companies/blocks/company-overview-section.tsx
+++ b/web/src/domains/companies/blocks/company-overview-section.tsx
@@ -1,4 +1,5 @@
 import { SectionCard } from "@/blocks/section-card";
+import { SourceCitation } from "@/blocks/source-citation";
 import { cn } from "@/lib/utils";
 import type { Company, CurrentCorporateRelationship, Source } from "@/types/domain";
 
@@ -105,10 +106,19 @@ const PENDING_GATEWAYS: Gateway[] = [
   },
 ];
 
-function formatSource(sources: Source[]): string | undefined {
-  if (sources.length === 0) return undefined;
+/**
+ * The section's citation. Company-info reports no filing date, so the citation
+ * is dated by when the record was last accessed.
+ */
+function OverviewSource({ sources }: { sources: Source[] }) {
   const [source] = sources;
-  return `${source.name} — ${source.url} (last accessed ${source.lastAccessed}).`;
+  if (!source) return null;
+  return (
+    <SourceCitation
+      source={source}
+      detail={`last accessed ${source.lastAccessed}`}
+    />
+  );
 }
 
 function GatewayCard({ gateway }: { gateway: Gateway }) {
@@ -173,7 +183,7 @@ export function CompanyOverviewSection({ company }: CompanyOverviewSectionProps)
       title="Overview"
       subtitle="Headline counts"
       info="Headline counts for the sections below. Only the corporate tree is sourced from a processor today; shareholder and commercial-debt figures require the shareholder-tracker and CDT processors and are shown as unavailable rather than estimated."
-      source={formatSource(company.sources)}
+      source={<OverviewSource sources={company.sources} />}
       expanded={
         <div className="max-w-3xl mx-auto">
           <Gateways gateways={gateways} />

--- a/web/src/domains/companies/blocks/company-overview-section.tsx
+++ b/web/src/domains/companies/blocks/company-overview-section.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { SectionCard } from "@/blocks/section-card";
 import { SourceCitation } from "@/blocks/source-citation";
+import { scrollToSection } from "@/lib/scroll-to-section";
 import { cn } from "@/lib/utils";
 import type { Company, CurrentCorporateRelationship, Source } from "@/types/domain";
 
@@ -13,7 +16,8 @@ type CompanyOverviewSectionProps = {
  * state rather than a fabricated figure.
  */
 type Gateway = {
-  href: string;
+  /** Target section id, without the `#`. */
+  section: string;
   kicker: string;
   value: string | null;
   unit: string;
@@ -58,7 +62,7 @@ function countJurisdictions(
 function treeGateway(company: Company): Gateway {
   const relationships = company.currentCorporateRelationships;
   const base = {
-    href: "#tree",
+    section: "tree",
     kicker: "Corporate Tree",
     unit: "Subsidiaries traced",
     link: "View corporate tree",
@@ -89,7 +93,7 @@ function treeGateway(company: Company): Gateway {
  */
 const PENDING_GATEWAYS: Gateway[] = [
   {
-    href: "#holders",
+    section: "holders",
     kicker: "Shareholders",
     value: null,
     unit: "Shareholders disclosed",
@@ -97,7 +101,7 @@ const PENDING_GATEWAYS: Gateway[] = [
     link: "View shareholders",
   },
   {
-    href: "#debt",
+    section: "debt",
     kicker: "Commercial Debt",
     value: null,
     unit: "Outstanding debt",
@@ -125,7 +129,13 @@ function GatewayCard({ gateway }: { gateway: Gateway }) {
   const unavailable = gateway.value === null;
   return (
     <a
-      href={gateway.href}
+      href={`#${gateway.section}`}
+      onClick={(event) => {
+        // Match the tab bar: smooth-scroll rather than let the browser jump to
+        // the fragment. The href stays so middle-click and open-in-new-tab work.
+        event.preventDefault();
+        scrollToSection(gateway.section);
+      }}
       className="group flex flex-col gap-1 p-4 md:p-6 hover:bg-overlay/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
     >
       <span className="font-mono text-[10px] uppercase tracking-wider text-muted">
@@ -156,7 +166,7 @@ function Gateways({ gateways }: { gateways: Gateway[] }) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-muted/15 -m-4 md:-m-6">
       {gateways.map((gateway) => (
-        <GatewayCard key={gateway.href} gateway={gateway} />
+        <GatewayCard key={gateway.section} gateway={gateway} />
       ))}
     </div>
   );

--- a/web/src/domains/companies/blocks/company-overview-section.tsx
+++ b/web/src/domains/companies/blocks/company-overview-section.tsx
@@ -82,7 +82,7 @@ function treeGateway(company: Company): Gateway {
   return {
     ...base,
     value: String(relationships.length),
-    meta: `${plural(jurisdictions, "jurisdiction")} · ${citation} · filed ${first.asOf}`,
+    meta: `${plural(jurisdictions, "jurisdiction")} · ${citation} · filed on ${first.asOf}`,
   };
 }
 

--- a/web/src/domains/companies/blocks/company-tabs.tsx
+++ b/web/src/domains/companies/blocks/company-tabs.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 
 import { SCROLL_PANE_ATTR } from "@/layouts";
+import { scrollToSection } from "@/lib/scroll-to-section";
 import { cn } from "@/lib/utils";
 
 type SectionTab = {
@@ -147,10 +148,7 @@ export function CompanyTabs({ companyName }: CompanyTabsProps) {
 
   const handleClick = (id: string) => (event: React.MouseEvent) => {
     event.preventDefault();
-    const target = document.getElementById(id);
-    if (!target) return;
-    target.scrollIntoView({ behavior: "smooth", block: "start" });
-    setActive(id);
+    if (scrollToSection(id)) setActive(id);
   };
 
   return (

--- a/web/src/domains/companies/blocks/company-tree-section.tsx
+++ b/web/src/domains/companies/blocks/company-tree-section.tsx
@@ -4,51 +4,45 @@ import { useMemo, useState } from "react";
 
 import { SectionCard } from "@/blocks/section-card";
 import { Pagination } from "@/components/pagination";
-import type { TreeEntity } from "@/domains/companies/types";
+import type { Company, CurrentCorporateRelationship } from "@/types/domain";
 
 type CompanyTreeSectionProps = {
-  tree: TreeEntity[];
-  source: string;
+  company: Company;
 };
 
-const ROOTS_PER_PAGE = 6;
+const SUBSIDIARIES_PER_PAGE = 25;
 
 /**
- * Group the flat tree entity list into contiguous chunks whose first entry
- * has depth 0 or 1 (roots). Each group is displayed as one page.
+ * A row in the rendered tree. The registrant is depth 0 and every disclosed
+ * subsidiary is depth 1: Exhibit 21 as the corporate-structure processor emits
+ * it is a flat list, with no nesting to recover. `depth` stays because GLEIF and
+ * 10-K body extraction are named future sources that would introduce real
+ * hierarchy.
  */
-function groupByRoot(entities: TreeEntity[]): TreeEntity[][] {
-  const groups: TreeEntity[][] = [];
-  let current: TreeEntity[] = [];
-  for (const entity of entities) {
-    if (entity.depth <= 1 && current.length > 0) {
-      groups.push(current);
-      current = [];
-    }
-    current.push(entity);
-  }
-  if (current.length > 0) groups.push(current);
-  return groups;
-}
+type TreeRow = {
+  name: string;
+  jurisdiction: string | null;
+  depth: number;
+};
 
 /**
  * Guide prefix for a row at `depth`, matching the design's tree: one
- * `\u2502` channel per ancestor level, then the `\u2514\u2500\u2500` branch for
+ * `│` channel per ancestor level, then the `└──` branch for
  * this one. Rendered as monospaced preformatted text so the columns line up by
  * character, independent of the proportional font used for entity names.
  */
 function guidePrefix(depth: number): string {
   if (depth === 0) return "";
-  return "   \u2502  ".repeat(depth - 1) + "\u2514\u2500\u2500 ";
+  return "   │  ".repeat(depth - 1) + "└── ";
 }
 
-function TreeLines({ entities }: { entities: TreeEntity[] }) {
+function TreeLines({ rows }: { rows: TreeRow[] }) {
   return (
     <div className="font-inter-tight text-[13px] text-foreground">
       <ul className="list-none m-0 p-0">
-        {entities.map((entity, i) => (
+        {rows.map((row, i) => (
           <li
-            key={`${entity.name}-${i}`}
+            key={`${row.name}-${i}`}
             className="grid grid-cols-[minmax(0,1fr)_auto] gap-4 py-0.5 hover:bg-overlay"
           >
             {/* Guides are a fixed-width prefix that does not shrink, so a name
@@ -59,12 +53,12 @@ function TreeLines({ entities }: { entities: TreeEntity[] }) {
                 aria-hidden
                 className="shrink-0 whitespace-pre font-mono text-muted"
               >
-                {guidePrefix(entity.depth)}
+                {guidePrefix(row.depth)}
               </span>
-              <span className="min-w-0">{entity.name}</span>
+              <span className="min-w-0">{row.name}</span>
             </span>
             <span className="font-mono text-[10px] uppercase tracking-wider text-muted whitespace-nowrap">
-              {entity.country}
+              {row.jurisdiction ?? ""}
             </span>
           </li>
         ))}
@@ -74,44 +68,114 @@ function TreeLines({ entities }: { entities: TreeEntity[] }) {
 }
 
 /**
- * The "Corporate Tree" section — indented, monospaced list of controlled
- * entities. Paginated by root grouping inline; the fullscreen modal renders
- * every entity unpaginated.
+ * The citation for the section. Every relationship in a company's list comes
+ * from the same filing, so one source covers all of them.
  */
-export function CompanyTreeSection({ tree, source }: CompanyTreeSectionProps) {
+function TreeSource({
+  relationship,
+}: {
+  relationship: CurrentCorporateRelationship;
+}) {
+  const [source] = relationship.sources;
+  if (!source) return null;
+  return (
+    <>
+      {source.name} —{" "}
+      <a
+        href={source.url}
+        className="underline hover:text-foreground"
+        target="_blank"
+        rel="noreferrer"
+      >
+        {source.url}
+      </a>{" "}
+      (filed {relationship.asOf}, retrieved {source.lastAccessed}).
+    </>
+  );
+}
+
+/**
+ * The "Corporate Tree" section — indented, monospaced list of the subsidiaries
+ * a company disclosed in its most recent Exhibit 21 (10-K) or Exhibit 8 (20-F).
+ *
+ * The jurisdiction column is the jurisdiction of incorporation exactly as
+ * filed. It is deliberately not normalized and deliberately not a country:
+ * "Delaware", "DE", and "United Kingdom" all occur in the source.
+ */
+export function CompanyTreeSection({ company }: CompanyTreeSectionProps) {
   const [page, setPage] = useState(1);
-  const groups = useMemo(() => groupByRoot(tree), [tree]);
-  const flatPageSize = ROOTS_PER_PAGE;
-  const totalGroups = groups.length;
-  const totalPages = Math.max(1, Math.ceil(totalGroups / flatPageSize));
-  const start = (page - 1) * flatPageSize;
-  const visibleGroups = groups.slice(start, start + flatPageSize);
-  const visible = visibleGroups.flat();
+  const relationships = company.currentCorporateRelationships;
+
+  const rows = useMemo<TreeRow[]>(
+    () => [
+      { name: company.name, jurisdiction: null, depth: 0 },
+      ...relationships.map((r) => ({
+        name: r.child.name,
+        jurisdiction: r.childJurisdiction,
+        depth: 1,
+      })),
+    ],
+    [company.name, relationships],
+  );
+
+  if (relationships.length === 0) {
+    return (
+      <SectionCard
+        id="tree"
+        title="Corporate Tree"
+        subtitle="No disclosed subsidiaries"
+        info="Subsidiaries disclosed in Exhibit 21 of a 10-K, or Exhibit 8 of a 20-F. Only companies that have filed one of those since the corporate-structure processor's coverage window have a tree."
+      >
+        <p className="text-sm text-muted leading-relaxed m-0">
+          No subsidiary disclosure is available for this company. A corporate
+          tree requires an Exhibit 21 or Exhibit 8 subsidiary list attached to a
+          10-K or 20-F, and none is in scope for this registrant.
+        </p>
+      </SectionCard>
+    );
+  }
+
+  // Every relationship for a company comes from one filing, so any of them
+  // carries the section's date and citation.
+  const [first] = relationships;
+  const totalPages = Math.max(
+    1,
+    Math.ceil(relationships.length / SUBSIDIARIES_PER_PAGE),
+  );
+  // The registrant heads page 1 only; subsidiaries paginate beneath it.
+  const start = (page - 1) * SUBSIDIARIES_PER_PAGE;
+  const visible: TreeRow[] = [
+    ...(page === 1 ? [rows[0]] : []),
+    ...rows.slice(1 + start, 1 + start + SUBSIDIARIES_PER_PAGE),
+  ];
+
+  const subsidiaryCount = relationships.length;
 
   return (
     <SectionCard
       id="tree"
       title="Corporate Tree"
-      subtitle={`${tree.length} entities · illustrative sample`}
-      info="Controlled subsidiaries and reconciled ownership relationships, sourced from filings that disclose material ownership stakes."
-      source={source}
+      subtitle={`${rows.length} entities · filed ${first.asOf}`}
+      info="Subsidiaries disclosed in Exhibit 21 of a 10-K, or Exhibit 8 of a 20-F, taken from this company's most recent such filing. The right-hand column is the jurisdiction of incorporation as disclosed, reproduced verbatim — it may name a US state or a country, and is not normalized. Exhibit 21 reports no ownership percentages, so no stake is shown."
+      source={<TreeSource relationship={first} />}
       expanded={
         <div className="max-w-3xl mx-auto">
-          <TreeLines entities={tree} />
-          {source ? (
-            <p className="mt-8 text-xs text-muted leading-relaxed">
-              <span className="font-mono uppercase tracking-wider font-medium mr-2">
-                Source.
-              </span>
-              {source}
-            </p>
-          ) : null}
+          <TreeLines rows={rows} />
+          <p className="mt-8 text-xs text-muted leading-relaxed">
+            <span className="font-mono uppercase tracking-wider font-medium mr-2">
+              Source.
+            </span>
+            <TreeSource relationship={first} />
+          </p>
         </div>
       }
     >
-      <TreeLines entities={visible} />
+      <TreeLines rows={visible} />
       {totalPages > 1 ? (
-        <div className="mt-4 flex justify-end">
+        <div className="mt-4 flex items-center justify-between gap-4">
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted m-0">
+            {subsidiaryCount} subsidiaries
+          </p>
           <Pagination
             variant="subtle"
             currentPage={page}

--- a/web/src/domains/companies/blocks/company-tree-section.tsx
+++ b/web/src/domains/companies/blocks/company-tree-section.tsx
@@ -154,7 +154,7 @@ function TreeSources({
             {i > 0 ? " " : null}
             <SourceCitation
               source={document.source}
-              detail={`${attribution}filed ${document.asOf}, retrieved ${document.source.lastAccessed}`}
+              detail={`${attribution}filed on ${document.asOf}, retrieved ${document.source.lastAccessed}`}
             />
           </span>
         );
@@ -223,9 +223,14 @@ export function CompanyTreeSection({ company }: CompanyTreeSectionProps) {
       id="tree"
       title="Corporate Tree"
       subtitle={
+        // "filed on" names the kind of date: an Exhibit 21 reaches EDGAR
+        // months after the fiscal period it describes, so a bare date reads as
+        // whichever the reader assumes. The range branch says "filings from"
+        // rather than gluing the endpoints together with "and" — a company with
+        // more than two registrants has dates between them.
         spansFilings
-          ? `${rows.length} entities · filed ${earliest} – ${latest}`
-          : `${rows.length} entities · filed ${earliest}`
+          ? `${rows.length} entities · filings from ${earliest} to ${latest}`
+          : `${rows.length} entities · filed on ${earliest}`
       }
       info="Subsidiaries disclosed in Exhibit 21 of a 10-K, or Exhibit 8 of a 20-F, taken from this company's most recent such filing. The right-hand column is the jurisdiction of incorporation as disclosed, reproduced verbatim — it may name a US state or a country, and is not normalized. Exhibit 21 reports no ownership percentages, so no stake is shown."
       source={<TreeSources company={company} relationships={relationships} />}

--- a/web/src/domains/companies/blocks/company-tree-section.tsx
+++ b/web/src/domains/companies/blocks/company-tree-section.tsx
@@ -69,8 +69,29 @@ function TreeLines({ rows }: { rows: TreeRow[] }) {
 }
 
 /**
- * The citation for the section. Every relationship in a company's list comes
- * from the same filing, so one source covers all of them.
+ * The span of filing dates a tree draws on.
+ *
+ * A single-registrant company has exactly one distinct `asOf`, because its rows
+ * all come from one document. A company with several registrants can be built
+ * from filings made on different days, so the section reports a range rather
+ * than claiming a date it does not have.
+ */
+function filingRange(relationships: CurrentCorporateRelationship[]) {
+  // ISO-8601 dates sort lexicographically, which is why these are plain strings
+  // throughout the domain model.
+  const dates = relationships
+    .map((relationship) => relationship.asOf)
+    .filter(Boolean)
+    .sort();
+  const earliest = dates[0];
+  const latest = dates[dates.length - 1];
+  return { earliest, latest, spansFilings: Boolean(earliest && latest && earliest !== latest) };
+}
+
+/**
+ * The citation for the section. Rows from one registrant share a filing, so one
+ * source covers them; a multi-registrant tree cites the first and relies on
+ * each row carrying its own `sources`.
  */
 function TreeSource({
   relationship,
@@ -128,9 +149,8 @@ export function CompanyTreeSection({ company }: CompanyTreeSectionProps) {
     );
   }
 
-  // Every relationship for a company comes from one filing, so any of them
-  // carries the section's date and citation.
   const [first] = relationships;
+  const { earliest, latest, spansFilings } = filingRange(relationships);
   const totalPages = Math.max(
     1,
     Math.ceil(relationships.length / SUBSIDIARIES_PER_PAGE),
@@ -148,7 +168,11 @@ export function CompanyTreeSection({ company }: CompanyTreeSectionProps) {
     <SectionCard
       id="tree"
       title="Corporate Tree"
-      subtitle={`${rows.length} entities · filed ${first.asOf}`}
+      subtitle={
+        spansFilings
+          ? `${rows.length} entities · filed ${earliest} – ${latest}`
+          : `${rows.length} entities · filed ${earliest}`
+      }
       info="Subsidiaries disclosed in Exhibit 21 of a 10-K, or Exhibit 8 of a 20-F, taken from this company's most recent such filing. The right-hand column is the jurisdiction of incorporation as disclosed, reproduced verbatim — it may name a US state or a country, and is not normalized. Exhibit 21 reports no ownership percentages, so no stake is shown."
       source={<TreeSource relationship={first} />}
       expanded={

--- a/web/src/domains/companies/blocks/company-tree-section.tsx
+++ b/web/src/domains/companies/blocks/company-tree-section.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 
 import { SectionCard } from "@/blocks/section-card";
+import { SourceCitation } from "@/blocks/source-citation";
 import { Pagination } from "@/components/pagination";
 import type { Company, CurrentCorporateRelationship } from "@/types/domain";
 
@@ -79,18 +80,10 @@ function TreeSource({
   const [source] = relationship.sources;
   if (!source) return null;
   return (
-    <>
-      {source.name} —{" "}
-      <a
-        href={source.url}
-        className="underline hover:text-foreground"
-        target="_blank"
-        rel="noreferrer"
-      >
-        {source.url}
-      </a>{" "}
-      (filed {relationship.asOf}, retrieved {source.lastAccessed}).
-    </>
+    <SourceCitation
+      source={source}
+      detail={`filed ${relationship.asOf}, retrieved ${source.lastAccessed}`}
+    />
   );
 }
 

--- a/web/src/domains/companies/blocks/company-tree-section.tsx
+++ b/web/src/domains/companies/blocks/company-tree-section.tsx
@@ -5,7 +5,11 @@ import { useMemo, useState } from "react";
 import { SectionCard } from "@/blocks/section-card";
 import { SourceCitation } from "@/blocks/source-citation";
 import { Pagination } from "@/components/pagination";
-import type { Company, CurrentCorporateRelationship } from "@/types/domain";
+import type {
+  Company,
+  CurrentCorporateRelationship,
+  Source,
+} from "@/types/domain";
 
 type CompanyTreeSectionProps = {
   company: Company;
@@ -89,22 +93,73 @@ function filingRange(relationships: CurrentCorporateRelationship[]) {
 }
 
 /**
- * The citation for the section. Rows from one registrant share a filing, so one
- * source covers them; a multi-registrant tree cites the first and relies on
- * each row carrying its own `sources`.
+ * The distinct documents a tree draws on, in the order their rows appear.
+ *
+ * Rows from one registrant share one filing, so a single-registrant company has
+ * exactly one document here. A company with several registrants unions each
+ * registrant's most recent filing, so the section can be built from two exhibits
+ * — and citing only the first left the footer disagreeing with the subtitle's
+ * filing range.
  */
-function TreeSource({
-  relationship,
+function distinctDocuments(relationships: CurrentCorporateRelationship[]) {
+  const byUrl = new Map<
+    string,
+    { source: Source; asOf: string; disclosedByCik: string }
+  >();
+  for (const relationship of relationships) {
+    const [source] = relationship.sources;
+    if (!source || byUrl.has(source.url)) continue;
+    byUrl.set(source.url, {
+      source,
+      asOf: relationship.asOf,
+      disclosedByCik: relationship.disclosedByCik,
+    });
+  }
+  return [...byUrl.values()];
+}
+
+/**
+ * The citation for the section — one entry per document the tree draws on.
+ *
+ * Two registrants filing separately produce two citations with the same source
+ * name ("SEC 10-K Exhibit 21"), so each is attributed to the registrant that
+ * disclosed it. A single-document tree carries no attribution: the whole section
+ * is that one filing, and naming the registrant would only repeat the company.
+ */
+function TreeSources({
+  company,
+  relationships,
 }: {
-  relationship: CurrentCorporateRelationship;
+  company: Company;
+  relationships: CurrentCorporateRelationship[];
 }) {
-  const [source] = relationship.sources;
-  if (!source) return null;
+  const documents = distinctDocuments(relationships);
+  if (documents.length === 0) return null;
+
+  const registrantNames = new Map(
+    company.registrants.map((registrant) => [
+      registrant.cik,
+      registrant.registrantName,
+    ]),
+  );
+
   return (
-    <SourceCitation
-      source={source}
-      detail={`filed ${relationship.asOf}, retrieved ${source.lastAccessed}`}
-    />
+    <>
+      {documents.map((document, i) => {
+        const registrant = registrantNames.get(document.disclosedByCik);
+        const attribution =
+          documents.length > 1 && registrant ? `${registrant}, ` : "";
+        return (
+          <span key={document.source.url}>
+            {i > 0 ? " " : null}
+            <SourceCitation
+              source={document.source}
+              detail={`${attribution}filed ${document.asOf}, retrieved ${document.source.lastAccessed}`}
+            />
+          </span>
+        );
+      })}
+    </>
   );
 }
 
@@ -149,7 +204,6 @@ export function CompanyTreeSection({ company }: CompanyTreeSectionProps) {
     );
   }
 
-  const [first] = relationships;
   const { earliest, latest, spansFilings } = filingRange(relationships);
   const totalPages = Math.max(
     1,
@@ -174,7 +228,7 @@ export function CompanyTreeSection({ company }: CompanyTreeSectionProps) {
           : `${rows.length} entities · filed ${earliest}`
       }
       info="Subsidiaries disclosed in Exhibit 21 of a 10-K, or Exhibit 8 of a 20-F, taken from this company's most recent such filing. The right-hand column is the jurisdiction of incorporation as disclosed, reproduced verbatim — it may name a US state or a country, and is not normalized. Exhibit 21 reports no ownership percentages, so no stake is shown."
-      source={<TreeSource relationship={first} />}
+      source={<TreeSources company={company} relationships={relationships} />}
       expanded={
         <div className="max-w-3xl mx-auto">
           <TreeLines rows={rows} />
@@ -182,7 +236,7 @@ export function CompanyTreeSection({ company }: CompanyTreeSectionProps) {
             <span className="font-mono uppercase tracking-wider font-medium mr-2">
               Source.
             </span>
-            <TreeSource relationship={first} />
+            <TreeSources company={company} relationships={relationships} />
           </p>
         </div>
       }

--- a/web/src/domains/companies/blocks/company-tree-section.tsx
+++ b/web/src/domains/companies/blocks/company-tree-section.tsx
@@ -11,7 +11,7 @@ type CompanyTreeSectionProps = {
   company: Company;
 };
 
-const SUBSIDIARIES_PER_PAGE = 25;
+const SUBSIDIARIES_PER_PAGE = 10;
 
 /**
  * A row in the rendered tree. The registrant is depth 0 and every disclosed

--- a/web/src/domains/companies/blocks/search-drawer.tsx
+++ b/web/src/domains/companies/blocks/search-drawer.tsx
@@ -79,6 +79,7 @@ function PanelBody({
         <SearchResult
           key={company.permId}
           index={startIndex + i + 1}
+          rankWidth={end.toString().length}
           company={company}
           viewedAt={company.viewedAt}
           active={company.permId === activeCompanyId}

--- a/web/src/domains/companies/blocks/search-result.tsx
+++ b/web/src/domains/companies/blocks/search-result.tsx
@@ -7,6 +7,13 @@ import { CompanyBookmark } from "./company-bookmark";
 
 type SearchResultProps = {
   index: number;
+  /**
+   * Digits to zero-pad the rank to. Pass the width of the highest rank on the
+   * page so every row's rank is the same width and the names line up; a page
+   * can straddle a digit boundary (91-100), which would otherwise leave the
+   * last rows indented past the rest.
+   */
+  rankWidth?: number;
   active?: boolean;
   company: CompanySearchMeta;
   viewedAt?: number;
@@ -14,6 +21,7 @@ type SearchResultProps = {
 
 export function SearchResult({
   index,
+  rankWidth = 2,
   active = false,
   company,
   viewedAt,
@@ -22,16 +30,19 @@ export function SearchResult({
   const { permId, companyName, sector, country, tickers } = company;
   return (
     <div
-      className={`grid grid-cols-8 text-sm border-b border-muted/25 p-3 cursor-pointer border-l-2 ${active ? "border-l-primary" : "border-l-transparent"} hover:bg-muted/10`}
+      // Columns are content-sized rather than fixed fractions: the rank grows
+      // past two digits deep in the result set and, pinned to one eighth of the
+      // panel, would otherwise overrun the name beside it.
+      className={`grid grid-cols-[auto_1fr_auto] gap-2 text-sm border-b border-muted/25 p-3 cursor-pointer border-l-2 ${active ? "border-l-primary" : "border-l-transparent"} hover:bg-muted/10`}
       onClick={() => router.push(`/companies/${permId}`)}
     >
-      <div className="col-span-1 text-muted text-xs font-mono leading-none">
+      <div className="text-muted text-xs font-mono leading-none">
         <div className="flex flex-row gap-2 items-start">
           <CompanyBookmark company={company} />
-          <p>{index.toString().padStart(2, "0")}</p>
+          <p>{index.toString().padStart(Math.max(2, rankWidth), "0")}</p>
         </div>
       </div>
-      <div className="col-span-5">
+      <div className="min-w-0">
         <div className="flex flex-col gap-1">
           <p className="font-bold text-xs leading-none">{companyName}</p>
           <p className="text-muted text-xs font-light leading-none">
@@ -48,7 +59,7 @@ export function SearchResult({
         </div>
       </div>
       {tickers && tickers.length > 0 && (
-        <div className="col-span-2 justify-self-end leading-none">
+        <div className="justify-self-end leading-none">
           <div className="flex flex-col gap-1">
             {tickers.map((ticker) => (
               <p

--- a/web/src/domains/companies/mock-sections.ts
+++ b/web/src/domains/companies/mock-sections.ts
@@ -1,19 +1,18 @@
 import type { Company } from "@/types/domain";
 
-import type { DebtInstrument, MockSections, Shareholder, TreeEntity } from "./types";
+import type { DebtInstrument, MockSections, Shareholder } from "./types";
 
 /**
- * Illustrative data for the three company-detail sections whose processors do
- * not exist yet: Corporate Tree, Holders, and Debt.
+ * Illustrative data for the two company-detail sections whose processors do
+ * not exist yet: Holders and Debt.
  *
  * NOTHING IN THIS FILE IS REAL. It exists so the page layout can be reviewed
- * before the corporate-structure, shareholder-tracker, and CDT processors
- * land, and every section that renders it says so in its source footer. Delete
- * each generator as its processor ships — do not extend this file to cover new
- * fields.
+ * before the shareholder-tracker and CDT processors land, and every section
+ * that renders it says so in its source footer. Delete each generator as its
+ * processor ships — do not extend this file to cover new fields.
  *
- * Company info (name, industry, country, ticker, exchange) is real and comes
- * from the pipeline; it is deliberately absent here.
+ * Company info and the corporate tree are real and come from the pipeline; they
+ * are deliberately absent here.
  */
 
 /**
@@ -88,48 +87,6 @@ const INSTRUMENTS = [
 
 const ILLUSTRATIVE = "Illustrative sample data — not sourced from any filing.";
 
-function makeTree(
-  rng: () => number,
-  company: Company,
-  countryPool: ReadonlyArray<{ name: string; country: string }>,
-): TreeEntity[] {
-  const rootName = company.name;
-  const root: TreeEntity = {
-    name: rootName,
-    country: company.hqCountry ?? "",
-    depth: 0,
-  };
-  const rootCount = 4 + Math.floor(rng() * 4);
-  const entities: TreeEntity[] = [root];
-  for (let i = 0; i < rootCount; i++) {
-    const country = pick(rng, countryPool);
-    const suffix = pick(rng, [
-      "Holdings",
-      "Corp",
-      "Mines Ltd",
-      "Trading SA",
-      "Energy",
-      "Resources",
-      "Agriculture",
-    ]);
-    const name = `${rootName.split(" ")[0]} ${suffix}`;
-    entities.push({ name, country: country.country, depth: 1 });
-    const childCount = Math.floor(rng() * 3);
-    for (let j = 0; j < childCount; j++) {
-      const child = pick(rng, countryPool);
-      const childName = `${name.split(" ")[0]} ${pick(rng, [
-        "Mining Ltd",
-        "Sarl",
-        "Plc",
-        "Coal Limited",
-        "Copper Mines",
-      ])}`;
-      entities.push({ name: childName, country: child.country, depth: 2 });
-    }
-  }
-  return entities;
-}
-
 function makeShareholders(rng: () => number): Shareholder[] {
   const count = 6 + Math.floor(rng() * 4);
   const shuffled = [...HOLDER_POOL].sort(() => rng() - 0.5).slice(0, count);
@@ -180,17 +137,15 @@ function makeDebtInstruments(rng: () => number): DebtInstrument[] {
 }
 
 /**
- * Build the deterministic, illustrative payload for the Tree, Holders, and
- * Debt sections. Seeded from `permId`, so the same company always renders the
- * same sample — safe for static generation.
+ * Build the deterministic, illustrative payload for the Holders and Debt
+ * sections. Seeded from `permId`, so the same company always renders the same
+ * sample — safe for static generation.
  */
 export function getMockSections(company: Company): MockSections {
   const rng = makeRng(company.permId);
   return {
-    tree: makeTree(rng, company, HOLDER_POOL),
     shareholders: makeShareholders(rng),
     debtInstruments: makeDebtInstruments(rng),
-    treeSource: `${ILLUSTRATIVE} Real subsidiaries will come from EDGAR Exhibit 21 via the corporate-structure processor.`,
     shareholdersSource: `${ILLUSTRATIVE} Real holdings will come from SEC Form 13-F via the shareholder-tracker processor.`,
     debtSource: `${ILLUSTRATIVE} Real instruments will come from SEC 8-K filings via the CDT processor.`,
   };

--- a/web/src/domains/companies/types.ts
+++ b/web/src/domains/companies/types.ts
@@ -1,23 +1,13 @@
 /**
  * View models for the company-detail sections that still render illustrative
- * data — Corporate Tree, Holders, and Debt.
+ * data — Holders and Debt.
  *
  * These are NOT domain types. The real, cited versions of these concepts live
- * in `@/types/domain` as `CorporateRelationship`, `HistoricShareholder`, and
- * `HistoricCommercialDebt`; each type here retires when its processor lands and
- * its section switches to the domain model.
+ * in `@/types/domain` as `HistoricShareholder` and `HistoricCommercialDebt`;
+ * each type here retires when its processor lands and its section switches to
+ * the domain model. The Corporate Tree already made that move — it reads
+ * `CurrentCorporateRelationship` from the domain model.
  */
-
-/**
- * A single entity in the corporate tree. `depth` is the indentation level;
- * 0 is the root registrant, positive integers indicate descendants.
- */
-export interface TreeEntity {
-  name: string;
-  country: string;
-  countryCode?: string;
-  depth: number;
-}
 
 /**
  * A single institutional or sovereign shareholder disclosed via 13-F/13-G.
@@ -47,15 +37,13 @@ export interface DebtInstrument {
 }
 
 /**
- * The illustrative payload for the three company-detail sections that have no
+ * The illustrative payload for the two company-detail sections that have no
  * processor yet. Produced by `mock-sections.ts`; every field is sample data, and
  * the `*Source` strings say so where they render.
  */
 export interface MockSections {
-  tree: TreeEntity[];
   shareholders: Shareholder[];
   debtInstruments: DebtInstrument[];
-  treeSource: string;
   shareholdersSource: string;
   debtSource: string;
 }

--- a/web/src/lib/scroll-to-section.ts
+++ b/web/src/lib/scroll-to-section.ts
@@ -1,0 +1,34 @@
+/**
+ * Scrolls the section with `id` into view, the way in-page navigation behaves
+ * everywhere on the company detail page.
+ *
+ * This exists so there is one definition of "go to a section" rather than one
+ * per call site. The tab bar and the Overview's stat cards both navigate to the
+ * same four sections, and they sit in sibling `blocks/` files that are not
+ * allowed to import each other, so the behaviour has to live a layer down.
+ *
+ * `scroll-margin-top` on the section cards is what keeps the target clear of the
+ * pinned tab bar — `scrollIntoView` honours it, so no pixel offset is applied
+ * here.
+ *
+ * Motion is animated only for readers who have not asked otherwise: `smooth`
+ * ignores `prefers-reduced-motion` on its own, so the preference is checked and
+ * the scroll falls back to an instant jump.
+ *
+ * @param id The target element's id, without a leading `#`.
+ * @returns Whether an element with that id was found.
+ */
+export function scrollToSection(id: string): boolean {
+  const target = document.getElementById(id);
+  if (!target) return false;
+
+  const prefersReducedMotion = window.matchMedia?.(
+    "(prefers-reduced-motion: reduce)",
+  ).matches;
+
+  target.scrollIntoView({
+    behavior: prefersReducedMotion ? "auto" : "smooth",
+    block: "start",
+  });
+  return true;
+}

--- a/web/src/types/domain.ts
+++ b/web/src/types/domain.ts
@@ -187,6 +187,33 @@ export type CorporateRelationship = CitedEntity &
     ownershipPercent: number | null;
   };
 
+/**
+ * A parent→child relationship as disclosed in a single filing. Exhibit 21 gives
+ * the date the relationship was *disclosed*, not the date it began — a
+ * subsidiary listed in a 2017 10-K may have been acquired decades earlier — so
+ * this is a {@link SnapshotEntity}. See {@link CorporateRelationship} for the
+ * date-ranged form, which needs a source that reports real start dates.
+ *
+ * `relationshipType` is always `"Subsidiary"` for Exhibit 21 data, whose
+ * heading is "Subsidiaries of the Registrant", and `ownershipPercent` is always
+ * null because the exhibit reports no percentages. Both fields are kept for
+ * GLEIF, which supplies them.
+ */
+export type CurrentCorporateRelationship = CitedEntity &
+  SnapshotEntity & {
+    parent: CompanyReference;
+    child: CompanyReference;
+    relationshipType: "Subsidiary" | "Division" | "JointVenture";
+    ownershipPercent: number | null;
+    /**
+     * Jurisdiction of incorporation as disclosed, verbatim. Mixed granularity
+     * and formatting — "Delaware", "DE", and "United Kingdom" all occur. This
+     * is deliberately not a country and deliberately not normalized: the value
+     * is what the filing says.
+     */
+    childJurisdiction: string | null;
+  };
+
 // ---------------------------------------------------------------------------
 // Equity securities
 // ---------------------------------------------------------------------------
@@ -310,6 +337,12 @@ export type Company = CitedEntity & {
   /** Broader classifications, e.g. TRBC economic and business sector. */
   currentSectors: CurrentSector[];
   currentListing: CurrentListing | null;
+  /**
+   * Subsidiaries as disclosed in this company's most recent Exhibit 21 (10-K)
+   * or Exhibit 8 (20-F). A snapshot rather than a date range — see
+   * {@link CurrentCorporateRelationship}.
+   */
+  currentCorporateRelationships: CurrentCorporateRelationship[];
 
   // History. Every entry needs a real `from` date; leave these empty rather
   // than inventing one. To get the current CEO, find the HistoricLeader with

--- a/web/src/types/domain.ts
+++ b/web/src/types/domain.ts
@@ -212,6 +212,12 @@ export type CurrentCorporateRelationship = CitedEntity &
      * is what the filing says.
      */
     childJurisdiction: string | null;
+    /**
+     * The registrant CIK whose filing disclosed this. Joins to
+     * {@link Company.registrants}. A company with several registrants renders
+     * one flat tree, so this is what says which of them is speaking.
+     */
+    disclosedByCik: string;
   };
 
 // ---------------------------------------------------------------------------
@@ -299,6 +305,35 @@ export type HistoricProjectAffiliation = CitedEntity &
   };
 
 // ---------------------------------------------------------------------------
+// SEC registrants
+// ---------------------------------------------------------------------------
+
+/**
+ * One SEC registrant rolling up to a company. A PermID may cover several —
+ * holdco/opco pairs, REIT/operating-partnership pairs, and utility groups all
+ * file under multiple CIKs that LSEG resolves to one entity.
+ *
+ * Company-facts fields are the intended next addition here. Facts are scalars
+ * reported per registrant — an operating partnership and its REIT have
+ * genuinely different market caps — so unlike the list-shaped sections they
+ * cannot be collapsed into one array.
+ */
+export type Registrant = CitedEntity &
+  SnapshotEntity & {
+    /** Zero-padded to 10 digits, the canonical SEC form. */
+    cik: string;
+    /**
+     * Legal name as reported against this CIK, from company-info's
+     * `entity_name`. Differs from the PermID entity name — "Brixmor Operating
+     * Partnership LP" against a company named "Brixmor Property Group Inc." —
+     * so it is what labels rows grouped by registrant.
+     */
+    registrantName: string | null;
+    /** True for exactly one registrant per company. */
+    isPrimary: boolean;
+  };
+
+// ---------------------------------------------------------------------------
 // Company
 // ---------------------------------------------------------------------------
 
@@ -306,10 +341,19 @@ export type Company = CitedEntity & {
   // Stable identifiers
   permId: string;
   /**
-   * Null when the company has no CIK, or when it has several and no primary
-   * has been selected — never guess a primary CIK.
+   * The primary registrant's CIK, mirroring the {@link Registrant} entry whose
+   * `isPrimary` is true. Null only when the company has no CIK at all.
+   *
+   * This is a denormalized convenience for display code that wants one CIK
+   * without scanning `registrants`. It is *not* the join key for per-CIK
+   * datasets — those join on every entry in `registrants`.
    */
   cik: string | null;
+  /**
+   * Every SEC registrant for this company, primary first. Empty if the company
+   * has no CIK.
+   */
+  registrants: Registrant[];
   ein: string | null;
   lei: string | null;
 


### PR DESCRIPTION
## Context

Closes [#19](https://github.com/dsi-clinic/idi-ftm2j-terminal/issues/19) — build the
corporate structure section from `corporate-structure/latest.parquet`, joined to
company info on `parent_cik`.

The join key that depends on was undefined for any PermID carrying more than one
CIK: `build_dataset.py` set `cik = None` in that case, so a multi-CIK company
would have silently rendered an empty tree rather than a wrong one. Multi-CIK 
support is therefore in this PR rather than a follow-up; rationale in
[#19 (comment)](https://github.com/dsi-clinic/idi-ftm2j-terminal/issues/19#issuecomment-5194175961).

## Changes

**Corporate structure**

- `attach_relationships` joins corporate structure to companies. Both sides of the CIK are zero-padded —
  unpadded the join matches nothing, silently, so a zero-match join now fails
  the build. Only the most recent filing per registrant contributes.
- Modelled as `CurrentCorporateRelationship` (a snapshot), not a date range:
  Exhibit 21 reports when a relationship was *disclosed*, not when it began.
  `childJurisdiction` is as-filed and unnormalized.
- Tree renders the real list, flat and paginated, with the registrant heading
  page 1. Overview bullets replaced by headline stats — only the tree has a
  processor, so the other two read "Not available" rather than sample figures.
- Methodology/downloads copy no longer credits GLEIF or claims normalization and
  manual review that don't exist.

**Multi-CIK**

- Every CIK for a PermID becomes a `Registrant`; `Company.cik` names the primary
  rather than going null when ambiguous. `select_primary_cik` is an isolated
  stub picking the lowest CIK — right for AEP and Brixmor, wrong for Entergy and
  Eversource, pending the company-facts processor.
- Structure unions across all registrants and keeps **one extraction per
  `accession_number`**: co-registrants on a combined filing are each attributed
  the same exhibit, so a naive union renders AEP's 22 subsidiaries as 132 rows.
  Each row carries `disclosedByCik`.
- Company scalars come from the most recent `(input_source, last_processed)`
  snapshot instead of `group.iloc[0]`, which picked one by parquet row order.
  CIKs are the deliberate exception and union across all rows. Disagreement
  *within* one snapshot raises a WARNING.
- Tree subtitle renders a filing-date range when a company's registrants filed
  on different days.
- `jobs/fixtures/` — 19 cases running the pipeline end to end against synthetic
  parquet. No PermID in production has more than one CIK, so this is the only
  coverage these paths have.
- `jobs/README.md` gains a per-CIK join contract so the pending shareholder and
  commercial-debt processors don't each invent one.

**Out of scope:** real primary-CIK logic (blocked on company-facts); deduping
the same subsidiary across two separate filings (deferred with measurements in
the README); shareholder and debt sections, still illustrative.

## Review requested

1. **The multi-CIK paths are unreachable on today's data — review the fixtures
   as the feature.** The build logs `0 companies joined more than one
   registrant`. Note `registrants_primary_is_lowest_cik_for_entergy` asserts a
   knowingly *wrong* answer so that fixing the heuristic shows as a diff.
3. **`select_latest_snapshot` changes where every scalar on every page comes
   from.** Output is identical today only because each PermID has exactly one
   snapshot; the first time a second source lands, `hqCountry`, `ticker` and
   `sources[].lastAccessed` can change with no code change.
4. **The accession collapse discards one co-registrant's extraction.** On 68 of
   203 shared accessions the parses genuinely differ (Brixmor: 619 rows vs 633
   from the same exhibit). Taking one whole copy always yields a list some parse
   produced, but it does drop real names.
5. **`domain.ts` gained two required fields with no validation at the JSON
   boundary** — `loadCompanies()` is an unchecked `JSON.parse` cast, so types and
   data can drift with no compile error.
6. Deduplication on multiple filings on the same date for the same CIK happens with report_date, which is written to the output as of https://github.com/dsi-clinic/idi-corporate-structure/pull/62